### PR TITLE
Cherry-picks storage features and technologies from Form Energy Storage Project

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -98,13 +98,18 @@ electricity:
     contingency: 4000
 
   max_hours:
-    battery: 6
-    H2: 168
+    li-ion battery: [6]
+    lfp: [6]
+    vanadium: [10]
+    lair: [12]
+    pair: [24]
+    H2: [168]
+    iron-air battery: [100]
 
   extendable_carriers:
     Generator: [solar, solar-hsat, onwind, offwind-ac, offwind-dc, offwind-float, OCGT, CCGT]
-    StorageUnit: [] # battery, H2
-    Store: [battery, H2]
+    StorageUnit: [] # li-ion battery, iron-air battery, H2, lfp, vanadium, lair, pair
+    Store: [li-ion battery, H2]
     Link: [] # H2 pipeline
 
   powerplants_filter: (DateOut >= 2024 or DateOut != DateOut) and not (Country == 'Germany' and Fueltype == 'Nuclear')
@@ -612,6 +617,7 @@ sector:
     micro_chp: false # Only gas is used for micro_chp
   solar_thermal: true
   solar_cf_correction: 0.788457  # =  >>> 1/1.2683
+  marginal_cost_storage: 0. #1e-4
   methanation: true
   coal_cc: false
   dac: true
@@ -857,7 +863,7 @@ costs:
     H2: 0.
     electrolysis: 0.
     fuel cell: 0.
-    battery: 0.
+    li-ion battery: 0.
     battery inverter: 0.
     home battery storage: 0
     water tank charger: 0.03
@@ -1064,7 +1070,9 @@ plotting:
     solar: "Solar"
     PHS: "Pumped Hydro Storage"
     hydro: "Reservoir & Dam"
-    battery: "Battery Storage"
+    li-ion battery: "Li-Ion Battery Storage"
+    li-ion home battery: "Li-Ion Home Battery Storage"
+    iron-air battery: "Iron-Air Battery Storage"
     H2: "Hydrogen Storage"
     lines: "Transmission Lines"
     ror: "Run of River"
@@ -1197,14 +1205,14 @@ plotting:
     industry new electricity: '#2d2a66'
     agriculture electricity: '#494778'
     # battery + EVs
-    battery: '#ace37f'
+    li-ion battery: '#ace37f'
     battery storage: '#ace37f'
-    battery charger: '#88a75b'
-    battery discharger: '#5d4e29'
-    home battery: '#80c944'
+    li-ion battery charger: '#88a75b'
+    li-ion battery discharger: '#5d4e29'
+    li-ion home battery: '#80c944'
     home battery storage: '#80c944'
-    home battery charger: '#5e8032'
-    home battery discharger: '#3c5221'
+    li-ion home battery charger: '#5e8032'
+    li-ion home battery discharger: '#3c5221'
     BEV charger: '#baf238'
     V2G: '#e5ffa8'
     land transport EV: '#baf238'

--- a/config/test/config.electricity.yaml
+++ b/config/test/config.electricity.yaml
@@ -30,7 +30,7 @@ electricity:
 
   extendable_carriers:
     Generator: [OCGT]
-    StorageUnit: [battery]
+    StorageUnit: [li-ion battery]
     Store: [H2]
     Link: [H2 pipeline]
 

--- a/config/test/config.myopic.yaml
+++ b/config/test/config.myopic.yaml
@@ -36,7 +36,7 @@ electricity:
 
   extendable_carriers:
     Generator: [OCGT]
-    StorageUnit: [battery]
+    StorageUnit: [li-ion battery]
     Store: [H2]
     Link: [H2 pipeline]
 

--- a/config/test/config.overnight.yaml
+++ b/config/test/config.overnight.yaml
@@ -30,7 +30,7 @@ electricity:
 
   extendable_carriers:
     Generator: [OCGT]
-    StorageUnit: [battery]
+    StorageUnit: [li-ion battery]
     Store: [H2]
     Link: [H2 pipeline]
 

--- a/config/test/config.perfect.yaml
+++ b/config/test/config.perfect.yaml
@@ -33,7 +33,7 @@ electricity:
 
   extendable_carriers:
     Generator: [OCGT]
-    StorageUnit: [battery]
+    StorageUnit: [li-ion battery]
     Store: [H2]
     Link: [H2 pipeline]
 

--- a/config/test/config.scenarios.yaml
+++ b/config/test/config.scenarios.yaml
@@ -31,7 +31,7 @@ snapshots:
 electricity:
   extendable_carriers:
     Generator: [OCGT]
-    StorageUnit: [battery, H2]
+    StorageUnit: [li-ion battery, H2]
     Store: []
 
 atlite:

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -14,12 +14,13 @@ operational_reserve,,,Settings for reserve requirements following `GenX <https:/
 -- epsilon_vres,--,float,share of total renewable supply
 -- contingency,MW,float,fixed reserve capacity
 max_hours,,,
--- battery,h,float,Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
--- H2,h,float,Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- li-ion battery,h,List of floats,Maximum state of charge capacity of the lithium-ion battery archetypes in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- H2,h,List of floats,Maximum state of charge capacity of the hydrogen storage archetypes in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- iron-air battery,h,List of floats,Maximum state of charge capacity of the iron-air battery archetypes in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
 extendable_carriers,,,
 -- Generator,--,Any extendable carrier,"Defines existing or non-existing conventional and renewable power plants to be extendable during the optimization. Conventional generators can only be built/expanded where already existent today. If a listed conventional carrier is not included in the ``conventional_carriers`` list, the lower limit of the capacity expansion is set to 0."
--- StorageUnit,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
--- Store,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
+-- StorageUnit,--,"Any subset of {'li-ion battery','H2'}",Adds extendable storage units (li-ion battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
+-- Store,--,"Any subset of {'li-ion battery','H2'}",Adds extendable storage units (li-ion battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
 -- Link,--,Any subset of {'H2 pipeline'},Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``.
 powerplants_filter,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country not in ['Germany']``",Filter query for the default powerplant database.
 ,,,

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -97,6 +97,7 @@ chp,--,,
 -- micro_chp,--,"{true, false}",Add option for using gas-fired Combined Heat and Power (CHP) for decentral areas.
 solar_thermal,--,"{true, false}",Add option for using solar thermal to generate heat.
 solar_cf_correction,--,float,The correction factor for the value provided by the solar thermal profile calculations
+marginal_cost_storage,"currency/MWh ",float,The marginal cost of discharging batteries in distributed grids
 marginal_cost_heat_vent,"currency/MWh ",float,The marginal cost of heat-venting in all heating systems
 methanation,--,"{true, false}",Add option for transforming hydrogen and CO2 into methane using methanation.
 coal_cc,--,"{true, false}",Add option for coal CHPs with carbon capture

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Added Iron-Air battery, Lithium iron phosphate (lpf), Vanadium, Liquid-air (lair) and Compressed-air (pair) storage technology and changed nomenclature for lithium-ion battery storages from ``battery`` to ``li-ion battery``.
+
 * Fail on solving status 'warning' because results are likely not valid.
 
 * Introduced heat-venting in all heating systems at given marginal cost and added marginal cost for water tank charging. Renamed config setting for marginal cost of home-battery charging to ``marginal_cost_home_battery_storage``. (https://github.com/PyPSA/pypsa-eur/pull/1563)

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1093,6 +1093,7 @@ rule prepare_sector_network:
         ),
         foresight=config_provider("foresight"),
         costs=config_provider("costs"),
+        max_hours=config_provider("electricity", "max_hours"),
         sector=config_provider("sector"),
         industry=config_provider("industry"),
         renewable=config_provider("renewable"),

--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -136,6 +136,7 @@ rule make_summary:
     params:
         foresight=config_provider("foresight"),
         costs=config_provider("costs"),
+        max_hours=config_provider("electricity", "max_hours"),
         snapshots=config_provider("snapshots"),
         drop_leap_day=config_provider("enable", "drop_leap_day"),
         scenario=config_provider("scenario"),

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -9,6 +9,7 @@ rule add_existing_baseyear:
         sector=config_provider("sector"),
         existing_capacities=config_provider("existing_capacities"),
         costs=config_provider("costs"),
+        max_hours=config_provider("electricity", "max_hours"),
         heat_pump_sources=config_provider("sector", "heat_pump_sources"),
         energy_totals_year=config_provider("energy", "energy_totals_year"),
     input:

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -146,7 +146,7 @@ def input_networks_make_summary_perfect(w):
 rule make_summary_perfect:
     params:
         costs=config_provider("costs"),
-        max_hours=config_provider("electricity","max_hours"),
+        max_hours=config_provider("electricity", "max_hours"),
     input:
         unpack(input_networks_make_summary_perfect),
         costs=resources("costs_2020.csv"),

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -7,6 +7,7 @@ rule add_existing_baseyear:
         sector=config_provider("sector"),
         existing_capacities=config_provider("existing_capacities"),
         costs=config_provider("costs"),
+        max_hours=config_provider("electricity", "max_hours"),
         heat_pump_sources=config_provider("sector", "heat_pump_sources"),
         energy_totals_year=config_provider("energy", "energy_totals_year"),
     input:
@@ -143,6 +144,9 @@ def input_networks_make_summary_perfect(w):
 
 
 rule make_summary_perfect:
+    params:
+        costs=config_provider("costs"),
+        max_hours=config_provider("electricity","max_hours"),
     input:
         unpack(input_networks_make_summary_perfect),
         costs=resources("costs_2020.csv"),

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -56,7 +56,7 @@ def add_brownfield(
     dc_i = n.links[n.links.carrier == "DC"].index
     n.links.loc[dc_i, "p_nom_min"] = n_p.links.loc[dc_i, "p_nom_opt"]
 
-    for c in n_p.iterate_components(["Link", "Generator", "Store"]):
+    for c in n_p.iterate_components(["Link", "Generator", "Store", "StorageUnit"]):
         attr = "e" if c.name == "Store" else "p"
 
         # first, remove generators, links and stores that track

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -211,7 +211,7 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
                 DeprecationWarning,
             )
             max_hours[carrier] = [max_hours[carrier]]
-            
+
     for key in ("marginal_cost", "capital_cost"):
         if key in config:
             config["overwrites"][key] = config[key]
@@ -1067,10 +1067,24 @@ def attach_storageunits(
 
     buses_i = n.buses.index
 
-    lookup_store = {"H2": "electrolysis", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery charge", "lfp": "Lithium-Ion-LFP-bicharger", 
-    "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-charger", "pair": "Compressed-Air-Adiabatic-bicharger"}
-    lookup_dispatch = {"H2": "fuel cell", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery discharge", "lfp": "Lithium-Ion-LFP-bicharger", 
-    "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-discharger", "pair": "Compressed-Air-Adiabatic-bicharger"}
+    lookup_store = {
+        "H2": "electrolysis",
+        "li-ion battery": "battery inverter",
+        "iron-air battery": "iron-air battery charge",
+        "lfp": "Lithium-Ion-LFP-bicharger",
+        "vanadium": "Vanadium-Redox-Flow-bicharger",
+        "lair": "Liquid-Air-charger",
+        "pair": "Compressed-Air-Adiabatic-bicharger",
+    }
+    lookup_dispatch = {
+        "H2": "fuel cell",
+        "li-ion battery": "battery inverter",
+        "iron-air battery": "iron-air battery discharge",
+        "lfp": "Lithium-Ion-LFP-bicharger",
+        "vanadium": "Vanadium-Redox-Flow-bicharger",
+        "lair": "Liquid-Air-discharger",
+        "pair": "Compressed-Air-Adiabatic-bicharger",
+    }
 
     for carrier in carriers:
         roundtrip_correction = 0.5 if carrier == "li-ion battery" else 1
@@ -1157,7 +1171,10 @@ def attach_stores(
 
     if "li-ion battery" in carriers:
         b_buses_i = n.add(
-            "Bus", buses_i + " li-ion battery", carrier="li-ion battery", location=buses_i
+            "Bus",
+            buses_i + " li-ion battery",
+            carrier="li-ion battery",
+            location=buses_i,
         )
 
         n.add(
@@ -1227,7 +1244,6 @@ if __name__ == "__main__":
         max_hours,
         Nyears,
     )
-    
 
     ppl = load_and_aggregate_powerplants(
         snakemake.input.powerplants,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -49,6 +49,7 @@ network with **zero** initial capacity:
 """
 
 import logging
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -201,6 +202,16 @@ def add_co2_emissions(n, costs, carriers):
 
 
 def load_costs(tech_costs, config, max_hours, Nyears=1.0):
+    print(max_hours)
+    # deprecation warning and casting float values to list of float values for max_hours per carrier
+    for carrier in max_hours:
+        if not isinstance(max_hours[carrier], list):
+            warnings.warn(
+                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
+                DeprecationWarning,
+            )
+            max_hours[carrier] = [max_hours[carrier]]
+            
     for key in ("marginal_cost", "capital_cost"):
         if key in config:
             config["overwrites"][key] = config[key]
@@ -250,24 +261,114 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
 
     costs = costs.rename({"solar-utility single-axis tracking": "solar-hsat"})
 
-    def costs_for_storage(store, link1, link2=None, max_hours=1.0):
-        capital_cost = link1["capital_cost"] + max_hours * store["capital_cost"]
+    def costs_for_storage(store, link1=None, link2=None, max_hours=1.0):
+        capital_cost = max_hours * store["capital_cost"]
+        # if charger/discharge link cost are already included in store capex
+        if link1 is not None:
+            capital_cost += link1["capital_cost"]
         if link2 is not None:
             capital_cost += link2["capital_cost"]
-        return pd.Series(
-            dict(capital_cost=capital_cost, marginal_cost=0.0, co2_emissions=0.0)
-        )
+        return pd.Series(dict(fixed=capital_cost, lifetime=store["lifetime"]))
 
-    costs.loc["battery"] = costs_for_storage(
+    for max_hour in max_hours["li-ion battery"]:
+        costs.loc[f"li-ion battery {max_hour}h"] = costs_for_storage(
+            costs.loc["battery storage"],
+            costs.loc["battery inverter"],
+            max_hours=max_hour,
+        )
+    # cost for default li-ion battery which will be the first max_hour archetype
+    costs.loc["li-ion battery"] = costs_for_storage(
         costs.loc["battery storage"],
         costs.loc["battery inverter"],
-        max_hours=max_hours["battery"],
+        max_hours=max_hours["li-ion battery"][0],
     )
+
+    for max_hour in max_hours["iron-air battery"]:
+        costs.loc[f"iron-air battery {max_hour}h"] = costs_for_storage(
+            costs.loc["iron-air battery"],
+            costs.loc["iron-air battery charge"],
+            costs.loc["iron-air battery discharge"],
+            max_hours=max_hour,
+        )
+
+    # cost for default iron-air battery which will be the first max_hour archetype
+    costs.loc["iron-air battery"] = costs_for_storage(
+        costs.loc["iron-air battery"],
+        costs.loc["iron-air battery charge"],
+        costs.loc["iron-air battery discharge"],
+        max_hours=max_hours["iron-air battery"][0],
+    )
+
+    for max_hour in max_hours["lfp"]:
+        costs.loc[f"lfp {max_hour}h"] = costs_for_storage(
+            costs.loc["Lithium-Ion-LFP-store"],
+            costs.loc["Lithium-Ion-LFP-bicharger"],
+            max_hours=max_hour,
+        )
+    # cost for default li-ion battery which will be the first max_hour archetype
+    costs.loc["lfp"] = costs_for_storage(
+        costs.loc["Lithium-Ion-LFP-store"],
+        costs.loc["Lithium-Ion-LFP-bicharger"],
+        max_hours=max_hours["lfp"][0],
+    )
+
+    for max_hour in max_hours["vanadium"]:
+        costs.loc[f"vanadium {max_hour}h"] = costs_for_storage(
+            costs.loc["Vanadium-Redox-Flow-store"],
+            costs.loc["Vanadium-Redox-Flow-bicharger"],
+            max_hours=max_hour,
+        )
+
+    # cost for default vanadium which will be the first max_hour archetype
+    costs.loc["vanadium"] = costs_for_storage(
+        costs.loc["Vanadium-Redox-Flow-store"],
+        costs.loc["Vanadium-Redox-Flow-bicharger"],
+        max_hours=max_hours["vanadium"][0],
+    )
+
+    for max_hour in max_hours["lair"]:
+        costs.loc[f"lair {max_hour}h"] = costs_for_storage(
+            costs.loc["Liquid-Air-store"],
+            costs.loc["Liquid-Air-charger"],
+            costs.loc["Liquid-Air-discharger"],
+            max_hours=max_hour,
+        )
+
+    # cost for default liquid air which will be the first max_hour archetype
+    costs.loc["lair"] = costs_for_storage(
+        costs.loc["Liquid-Air-store"],
+        costs.loc["Liquid-Air-charger"],
+        costs.loc["Liquid-Air-discharger"],
+        max_hours=max_hours["lair"][0],
+    )
+
+    for max_hour in max_hours["pair"]:
+        costs.loc[f"pair {max_hour}h"] = costs_for_storage(
+            costs.loc["Compressed-Air-Adiabatic-store"],
+            costs.loc["Compressed-Air-Adiabatic-bicharger"],
+            max_hours=max_hour,
+        )
+
+    # cost for default CAES which will be the first max_hour archetype
+    costs.loc["pair"] = costs_for_storage(
+        costs.loc["Compressed-Air-Adiabatic-store"],
+        costs.loc["Compressed-Air-Adiabatic-bicharger"],
+        max_hours=max_hours["pair"][0],
+    )
+
+    for max_hour in max_hours["H2"]:
+        costs.loc[f"H2 {max_hour}h"] = costs_for_storage(
+            costs.loc["hydrogen storage underground"],
+            costs.loc["fuel cell"],
+            costs.loc["electrolysis"],
+            max_hours=max_hour,
+        )
+    # cost for default H2 underground storage which will be the first max_hour archetype
     costs.loc["H2"] = costs_for_storage(
         costs.loc["hydrogen storage underground"],
         costs.loc["fuel cell"],
         costs.loc["electrolysis"],
-        max_hours=max_hours["H2"],
+        max_hours=max_hours["H2"][0],
     )
 
     for attr in ("marginal_cost", "capital_cost"):
@@ -966,28 +1067,30 @@ def attach_storageunits(
 
     buses_i = n.buses.index
 
-    lookup_store = {"H2": "electrolysis", "battery": "battery inverter"}
-    lookup_dispatch = {"H2": "fuel cell", "battery": "battery inverter"}
+    lookup_store = {"H2": "electrolysis", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery charge", "lfp": "Lithium-Ion-LFP-bicharger", 
+    "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-charger", "pair": "Compressed-Air-Adiabatic-bicharger"}
+    lookup_dispatch = {"H2": "fuel cell", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery discharge", "lfp": "Lithium-Ion-LFP-bicharger", 
+    "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-discharger", "pair": "Compressed-Air-Adiabatic-bicharger"}
 
     for carrier in carriers:
-        roundtrip_correction = 0.5 if carrier == "battery" else 1
-
-        n.add(
-            "StorageUnit",
-            buses_i,
-            " " + carrier,
-            bus=buses_i,
-            carrier=carrier,
-            p_nom_extendable=True,
-            capital_cost=costs.at[carrier, "capital_cost"],
-            marginal_cost=costs.at[carrier, "marginal_cost"],
-            efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
-            ** roundtrip_correction,
-            efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
-            ** roundtrip_correction,
-            max_hours=max_hours[carrier],
-            cyclic_state_of_charge=True,
-        )
+        roundtrip_correction = 0.5 if carrier == "li-ion battery" else 1
+        for max_hour in max_hours[carrier]:
+            n.add(
+                "StorageUnit",
+                buses_i,
+                f" {carrier} {max_hour}h",
+                bus=buses_i,
+                carrier=carrier,
+                p_nom_extendable=True,
+                capital_cost=costs.at[f"{carrier} {max_hour}h", "capital_cost"],
+                marginal_cost=costs.at[f"{carrier} {max_hour}h", "marginal_cost"],
+                efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
+                ** roundtrip_correction,
+                efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
+                ** roundtrip_correction,
+                max_hours=max_hour,
+                cyclic_state_of_charge=True,
+            )
 
 
 def attach_stores(
@@ -1052,30 +1155,30 @@ def attach_stores(
             marginal_cost=costs.at["fuel cell", "marginal_cost"],
         )
 
-    if "battery" in carriers:
+    if "li-ion battery" in carriers:
         b_buses_i = n.add(
-            "Bus", buses_i + " battery", carrier="battery", location=buses_i
+            "Bus", buses_i + " li-ion battery", carrier="li-ion battery", location=buses_i
         )
 
         n.add(
             "Store",
             b_buses_i,
             bus=b_buses_i,
-            carrier="battery",
+            carrier="li-ion battery",
             e_cyclic=True,
             e_nom_extendable=True,
             capital_cost=costs.at["battery storage", "capital_cost"],
-            marginal_cost=costs.at["battery", "marginal_cost"],
+            marginal_cost=costs.at["li-ion battery", "marginal_cost"],
         )
 
-        n.add("Carrier", ["battery charger", "battery discharger"])
+        n.add("Carrier", ["li-ion battery charger", "li-ion battery discharger"])
 
         n.add(
             "Link",
             b_buses_i + " charger",
             bus0=buses_i,
             bus1=b_buses_i,
-            carrier="battery charger",
+            carrier="li-ion battery charger",
             # the efficiencies are "round trip efficiencies"
             efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
             capital_cost=costs.at["battery inverter", "capital_cost"],
@@ -1088,7 +1191,7 @@ def attach_stores(
             b_buses_i + " discharger",
             bus0=b_buses_i,
             bus1=buses_i,
-            carrier="battery discharger",
+            carrier="li-ion battery discharger",
             efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
             p_nom_extendable=True,
             marginal_cost=costs.at["battery inverter", "marginal_cost"],
@@ -1124,6 +1227,7 @@ if __name__ == "__main__":
         max_hours,
         Nyears,
     )
+    
 
     ppl = load_and_aggregate_powerplants(
         snakemake.input.powerplants,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -202,7 +202,6 @@ def add_co2_emissions(n, costs, carriers):
 
 
 def load_costs(tech_costs, config, max_hours, Nyears=1.0):
-    print(max_hours)
     # deprecation warning and casting float values to list of float values for max_hours per carrier
     for carrier in max_hours:
         if not isinstance(max_hours[carrier], list):
@@ -1063,8 +1062,6 @@ def attach_storageunits(
     """
     carriers = extendable_carriers["StorageUnit"]
 
-    n.add("Carrier", carriers)
-
     buses_i = n.buses.index
 
     lookup_store = {
@@ -1089,12 +1086,14 @@ def attach_storageunits(
     for carrier in carriers:
         roundtrip_correction = 0.5 if carrier == "li-ion battery" else 1
         for max_hour in max_hours[carrier]:
+            n.add("Carrier", f" {carrier} {max_hour}h")
+
             n.add(
                 "StorageUnit",
                 buses_i,
                 f" {carrier} {max_hour}h",
                 bus=buses_i,
-                carrier=carrier,
+                carrier=f" {carrier} {max_hour}h",
                 p_nom_extendable=True,
                 capital_cost=costs.at[f"{carrier} {max_hour}h", "capital_cost"],
                 marginal_cost=costs.at[f"{carrier} {max_hour}h", "marginal_cost"],

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -43,7 +43,7 @@ def add_build_year_to_new_assets(n: pypsa.Network, baseyear: int) -> None:
         Year in which optimized assets are built
     """
     # Give assets with lifetimes and no build year the build year baseyear
-    for c in n.iterate_components(["Link", "Generator", "Store"]):
+    for c in n.iterate_components(["Link", "Generator", "Store", "StorageUnit"]):
         assets = c.df.index[(c.df.lifetime != np.inf) & (c.df.build_year == 0)]
         c.df.loc[assets, "build_year"] = baseyear
 
@@ -728,7 +728,7 @@ if __name__ == "__main__":
     Nyears = n.snapshot_weightings.generators.sum() / 8760.0
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.costs,
+        snakemake.params,
         Nyears,
     )
 

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -318,7 +318,7 @@ def calculate_supply(n, label, supply):
         for c in n.iterate_components(n.one_port_components):
             items = c.df.index[c.df.bus.map(bus_map).fillna(False)]
 
-            if len(items) == 0:
+            if len(items) == 0 or len(c.pnl.p.columns) == 0:
                 continue
 
             s = (
@@ -369,7 +369,7 @@ def calculate_supply_energy(n, label, supply_energy):
         for c in n.iterate_components(n.one_port_components):
             items = c.df.index[c.df.bus.map(bus_map).fillna(False)]
 
-            if len(items) == 0:
+            if len(items) == 0 or len(c.pnl.p.columns) == 0:
                 continue
 
             s = (
@@ -424,7 +424,7 @@ def calculate_nodal_supply_energy(n, label, nodal_supply_energy):
         for c in n.iterate_components(n.one_port_components):
             items = c.df.index[c.df.bus.map(bus_map).fillna(False)]
 
-            if len(items) == 0:
+            if len(items) == 0 or len(c.pnl.p.columns) == 0:
                 continue
 
             s = (
@@ -719,7 +719,7 @@ if __name__ == "__main__":
 
     costs_db = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.costs,
+        snakemake.params,
         Nyears,
     )
 

--- a/scripts/make_summary_perfect.py
+++ b/scripts/make_summary_perfect.py
@@ -288,7 +288,7 @@ def calculate_supply(n, label, supply):
         for c in n.iterate_components(n.one_port_components):
             items = c.df.index[c.df.bus.map(bus_map).fillna(False)]
 
-            if len(items) == 0:
+            if len(items) == 0 or len(c.pnl.p.columns) == 0:
                 continue
 
             s = (
@@ -351,7 +351,7 @@ def calculate_supply_energy(n, label, supply_energy):
         for c in n.iterate_components(n.one_port_components):
             items = c.df.index[c.df.bus.map(bus_map).fillna(False)]
 
-            if len(items) == 0:
+            if len(items) == 0 or len(c.pnl.p.columns) == 0:
                 continue
 
             if c.name == "Generator":
@@ -735,7 +735,7 @@ if __name__ == "__main__":
     nyears = 1
     costs_db = prepare_costs(
         snakemake.input.costs,
-        snakemake.config["costs"],
+        snakemake.params,
         nyears,
     )
 

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -427,7 +427,7 @@ def plot_carbon_budget_distribution(input_eurostat, options):
         co2_cap = (
             supply_energy.loc["co2"].droplevel(0).drop("co2").sum().unstack().T / 1e9
         )
-        co2_cap.rename(index=lambda x: int(x), inplace=True)
+        co2_cap.rename(index=lambda x: int(float(x)), inplace=True)
 
     plt.figure(figsize=(10, 7))
     gs1 = gridspec.GridSpec(1, 1)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -7,8 +7,8 @@ technologies for the buildings, transport and industry sectors.
 """
 
 import logging
-import warnings
 import os
+import warnings
 from itertools import product
 from types import SimpleNamespace
 
@@ -1211,10 +1211,9 @@ def cycling_shift(df, steps=1):
 
 
 def prepare_costs(cost_file, params_all, nyears):
-
     params = params_all.costs
     max_hours = params_all.max_hours
-   # deprecation warning and casting float values to list of float values for max_hours per carrier
+    # deprecation warning and casting float values to list of float values for max_hours per carrier
     for carrier in max_hours:
         if not isinstance(max_hours[carrier], list):
             warnings.warn(
@@ -1265,7 +1264,7 @@ def prepare_costs(cost_file, params_all, nyears):
             logger.info(
                 f"Overwriting {attr} of {overwrites.index} to {overwrites.values}"
             )
-    
+
     def costs_for_storage(store, link1=None, link2=None, max_hours=1.0):
         capital_cost = max_hours * store["capital_cost"]
         # if charger/discharge link cost are already included in store capex
@@ -1577,7 +1576,9 @@ def insert_electricity_distribution_grid(n, costs):
             lifetime=costs.at["home battery inverter", "lifetime"],
         )
 
-    elif "battery" in snakemake.params.electricity["extendable_carriers"]["StorageUnit"]:
+    elif (
+        "battery" in snakemake.params.electricity["extendable_carriers"]["StorageUnit"]
+    ):
         n.add("Carrier", "li-ion home battery")
         max_hours = snakemake.params.max_hours
         for max_hour in max_hours["li-ion battery"]:
@@ -1588,10 +1589,13 @@ def insert_electricity_distribution_grid(n, costs):
                 bus=nodes + " low voltage",
                 carrier="li-ion home battery",
                 p_nom_extendable=True,
-                capital_cost=costs.at[f"li-ion home battery {max_hour}h", "capital_cost"],
+                capital_cost=costs.at[
+                    f"li-ion home battery {max_hour}h", "capital_cost"
+                ],
                 marginal_cost=options["marginal_cost_storage"],
                 efficiency_store=costs.at["home battery inverter", "efficiency"] ** 0.5,
-                efficiency_dispatch=costs.at["home battery inverter", "efficiency"] ** 0.5,
+                efficiency_dispatch=costs.at["home battery inverter", "efficiency"]
+                ** 0.5,
                 max_hours=max_hour,
                 cyclic_state_of_charge=True,
                 lifetime=costs.at["home battery storage", "lifetime"],
@@ -1630,6 +1634,7 @@ def add_electricity_grid_connection(n, costs):
         "electricity grid connection", "capital_cost"
     ]
 
+
 def get_salt_caverns(cavern_types, fn_h2_cavern):
     h2_caverns = pd.read_csv(fn_h2_cavern, index_col=0)
 
@@ -1658,7 +1663,15 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
     nodes = pop_layout.index
 
     # check for not implemented storage technologies
-    implemented = ["H2", "li-ion battery", "iron-air battery", "lfp", "vanadium", "lair", "pair"]
+    implemented = [
+        "H2",
+        "li-ion battery",
+        "iron-air battery",
+        "lfp",
+        "vanadium",
+        "lair",
+        "pair",
+    ]
     not_implemented = list(set(carriers).difference(implemented))
     available_carriers = list(set(carriers).intersection(implemented))
     if len(not_implemented) > 0:
@@ -1668,10 +1681,24 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
     missing_carriers = list(set(available_carriers).difference(n.carriers.index))
     n.add("Carrier", missing_carriers)
 
-    lookup_store = {"H2": "electrolysis", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery charge",
-    "lfp": "Lithium-Ion-LFP-bicharger", "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-charger", "pair": "Compressed-Air-Adiabatic-bicharger"}
-    lookup_dispatch = {"H2": "fuel cell", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery discharge",
-    "lfp": "Lithium-Ion-LFP-bicharger", "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-discharger", "pair": "Compressed-Air-Adiabatic-bicharger"}
+    lookup_store = {
+        "H2": "electrolysis",
+        "li-ion battery": "battery inverter",
+        "iron-air battery": "iron-air battery charge",
+        "lfp": "Lithium-Ion-LFP-bicharger",
+        "vanadium": "Vanadium-Redox-Flow-bicharger",
+        "lair": "Liquid-Air-charger",
+        "pair": "Compressed-Air-Adiabatic-bicharger",
+    }
+    lookup_dispatch = {
+        "H2": "fuel cell",
+        "li-ion battery": "battery inverter",
+        "iron-air battery": "iron-air battery discharge",
+        "lfp": "Lithium-Ion-LFP-bicharger",
+        "vanadium": "Vanadium-Redox-Flow-bicharger",
+        "lair": "Liquid-Air-discharger",
+        "pair": "Compressed-Air-Adiabatic-bicharger",
+    }
 
     for carrier in available_carriers:
         for max_hour in max_hours[carrier]:
@@ -1686,7 +1713,9 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
                     carrier=carrier,
                     p_nom_extendable=True,
                     p_nom_max=h2_caverns.div(max_hour).values,
-                    capital_cost=costs.at[f"H2 underground {max_hour}h", "capital_cost"],
+                    capital_cost=costs.at[
+                        f"H2 underground {max_hour}h", "capital_cost"
+                    ],
                     marginal_cost=options["marginal_cost_storage"],
                     efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
                     ** roundtrip_correction,
@@ -1703,7 +1732,11 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
                 nodes_ = nodes
 
             cost_carrier = "H2 tank" if carrier == "H2" else carrier
-            cost_carrier = "iron-air battery storage" if carrier == "iron-air battery" else cost_carrier
+            cost_carrier = (
+                "iron-air battery storage"
+                if carrier == "iron-air battery"
+                else cost_carrier
+            )
             n.add(
                 "StorageUnit",
                 nodes_,
@@ -1721,7 +1754,7 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
                 cyclic_state_of_charge=True,
                 lifetime=costs.at[f"{cost_carrier} {max_hour}h", "lifetime"],
             )
-    
+
     logger.info(f"Adding storage_units with carrier {available_carriers}")
 
 
@@ -1778,9 +1811,12 @@ def add_stores(n, costs, carriers, h2_caverns):
         )
 
     if "li-ion battery" in carriers:
-
         n.add(
-            "Bus", nodes + " li-ion battery", location=nodes, carrier="li-ion battery", unit="MWh_el"
+            "Bus",
+            nodes + " li-ion battery",
+            location=nodes,
+            carrier="li-ion battery",
+            unit="MWh_el",
         )
 
         n.add(
@@ -1819,9 +1855,12 @@ def add_stores(n, costs, carriers, h2_caverns):
         )
 
     if "iron-air battery" in carriers:
-
         n.add(
-            "Bus", nodes + " iron-air battery", location=nodes, carrier="iron-air battery", unit="MWh_el"
+            "Bus",
+            nodes + " iron-air battery",
+            location=nodes,
+            carrier="iron-air battery",
+            unit="MWh_el",
         )
 
         n.add(
@@ -1861,6 +1900,7 @@ def add_stores(n, costs, carriers, h2_caverns):
         )
 
     logger.info(f"Adding stores with carrier {carriers}")
+
 
 def add_storage_and_grids(
     n,
@@ -2145,7 +2185,13 @@ def add_storage_and_grids(
     h2_caverns = get_salt_caverns(cavern_types, h2_cavern_file)
 
     add_stores(n, costs, options["extendable_carriers"]["Store"], h2_caverns)
-    add_storageunits(n, costs, options["extendable_carriers"]["StorageUnit"], snakemake.params.max_hours, h2_caverns)
+    add_storageunits(
+        n,
+        costs,
+        options["extendable_carriers"]["StorageUnit"],
+        snakemake.params.max_hours,
+        h2_caverns,
+    )
 
     if options["methanation"]:
         n.add(
@@ -5527,7 +5573,9 @@ if __name__ == "__main__":
     update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     options = snakemake.params.sector
-    options["extendable_carriers"] = snakemake.params.electricity.get("extendable_carriers", dict())
+    options["extendable_carriers"] = snakemake.params.electricity.get(
+        "extendable_carriers", dict()
+    )
     cf_industry = snakemake.params.industry
 
     investment_year = int(snakemake.wildcards.planning_horizons)

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1678,7 +1678,15 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
         logger.warning(
             f"{not_implemented} are not yet implemented as Storage technologies in PyPSA-Eur"
         )
-    missing_carriers = list(set(available_carriers).difference(n.carriers.index))
+    available_carriers_max_hours = [
+        f"{carrier} {max_hour}"
+        for carrier in available_carriers
+        if carrier in max_hours
+        for max_hour in max_hours[carrier]
+    ]
+    missing_carriers = list(
+        set(available_carriers_max_hours).difference(n.carriers.index)
+    )
     n.add("Carrier", missing_carriers)
 
     lookup_store = {
@@ -1710,7 +1718,7 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
                     h2_caverns.index,
                     suffix=f" {carrier} {max_hour}h",
                     bus=h2_caverns.index,
-                    carrier=carrier,
+                    carrier=f"{carrier} {max_hour}h",
                     p_nom_extendable=True,
                     p_nom_max=h2_caverns.div(max_hour).values,
                     capital_cost=costs.at[
@@ -1742,7 +1750,7 @@ def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
                 nodes_,
                 suffix=f" {carrier} {max_hour}h",
                 bus=nodes_,
-                carrier=carrier,
+                carrier=f"{carrier} {max_hour}h",
                 p_nom_extendable=True,
                 capital_cost=costs.at[f"{cost_carrier} {max_hour}h", "capital_cost"],
                 marginal_cost=options["marginal_cost_storage"],

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -7,6 +7,7 @@ technologies for the buildings, transport and industry sectors.
 """
 
 import logging
+import warnings
 import os
 from itertools import product
 from types import SimpleNamespace
@@ -1209,7 +1210,19 @@ def cycling_shift(df, steps=1):
     return df
 
 
-def prepare_costs(cost_file, params, nyears):
+def prepare_costs(cost_file, params_all, nyears):
+
+    params = params_all.costs
+    max_hours = params_all.max_hours
+   # deprecation warning and casting float values to list of float values for max_hours per carrier
+    for carrier in max_hours:
+        if not isinstance(max_hours[carrier], list):
+            warnings.warn(
+                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
+                DeprecationWarning,
+            )
+            max_hours[carrier] = [max_hours[carrier]]
+
     for key in ("marginal_cost", "capital_cost"):
         if key in params:
             params["overwrites"][key] = params[key]
@@ -1252,6 +1265,76 @@ def prepare_costs(cost_file, params, nyears):
             logger.info(
                 f"Overwriting {attr} of {overwrites.index} to {overwrites.values}"
             )
+    
+    def costs_for_storage(store, link1=None, link2=None, max_hours=1.0):
+        capital_cost = max_hours * store["capital_cost"]
+        # if charger/discharge link cost are already included in store capex
+        if link1 is not None:
+            capital_cost += link1["capital_cost"]
+        if link2 is not None:
+            capital_cost += link2["capital_cost"]
+        return pd.Series(dict(fixed=capital_cost, lifetime=store["lifetime"]))
+
+    # TODO: storage capex might have to be adjusted for different max hour archetypes
+    for max_hour in max_hours["li-ion battery"]:
+        costs.loc[f"li-ion battery {max_hour}h"] = costs_for_storage(
+            costs.loc["battery storage"],
+            costs.loc["battery inverter"],
+            max_hours=max_hour,
+        )
+        costs.loc[f"li-ion home battery {max_hour}h"] = costs_for_storage(
+            costs.loc["home battery storage"],
+            costs.loc["home battery inverter"],
+            max_hours=max_hour,
+        )
+
+    for max_hour in max_hours["lfp"]:
+        costs.loc[f"lfp {max_hour}h"] = costs_for_storage(
+            costs.loc["Lithium-Ion-LFP-store"],
+            costs.loc["Lithium-Ion-LFP-bicharger"],
+            max_hours=max_hour,
+        )
+
+    for max_hour in max_hours["vanadium"]:
+        costs.loc[f"vanadium {max_hour}h"] = costs_for_storage(
+            costs.loc["Vanadium-Redox-Flow-store"],
+            costs.loc["Vanadium-Redox-Flow-bicharger"],
+            max_hours=max_hour,
+        )
+
+    for max_hour in max_hours["lair"]:
+        costs.loc[f"lair {max_hour}h"] = costs_for_storage(
+            costs.loc["Liquid-Air-store"],
+            costs.loc["Liquid-Air-charger"],
+            costs.loc["Liquid-Air-discharger"],
+            max_hours=max_hour,
+        )
+
+    for max_hour in max_hours["pair"]:
+        costs.loc[f"pair {max_hour}h"] = costs_for_storage(
+            costs.loc["Compressed-Air-Adiabatic-store"],
+            costs.loc["Compressed-Air-Adiabatic-bicharger"],
+            max_hours=max_hour,
+        )
+
+    for max_hour in max_hours["iron-air battery"]:
+        costs.loc[f"iron-air battery storage {max_hour}h"] = costs_for_storage(
+            costs.loc["iron-air battery"],
+            max_hours=max_hour,
+        )
+    for max_hour in max_hours["H2"]:
+        costs.loc[f"H2 underground {max_hour}h"] = costs_for_storage(
+            costs.loc["hydrogen storage underground"],
+            costs.loc["fuel cell"],
+            costs.loc["electrolysis"],
+            max_hours=max_hour,
+        )
+        costs.loc[f"H2 tank {max_hour}h"] = costs_for_storage(
+            costs.loc["hydrogen storage tank type 1 including compressor"],
+            costs.loc["fuel cell"],
+            costs.loc["electrolysis"],
+            max_hours=max_hour,
+        )
 
     return costs
 
@@ -1447,51 +1530,72 @@ def insert_electricity_distribution_grid(n, costs):
         lifetime=costs.at["solar-rooftop", "lifetime"],
     )
 
-    n.add("Carrier", "home battery")
+    if "li-ion battery" in snakemake.params.electricity["extendable_carriers"]["Store"]:
+        n.add("Carrier", "li-ion home battery")
 
-    n.add(
-        "Bus",
-        nodes + " home battery",
-        location=nodes,
-        carrier="home battery",
-        unit="MWh_el",
-    )
+        n.add(
+            "Bus",
+            nodes + " li-ion home battery",
+            location=nodes,
+            carrier="li-ion home battery",
+            unit="MWh_el",
+        )
 
-    n.add(
-        "Store",
-        nodes + " home battery",
-        bus=nodes + " home battery",
-        location=nodes,
-        e_cyclic=True,
-        e_nom_extendable=True,
-        carrier="home battery",
-        capital_cost=costs.at["home battery storage", "capital_cost"],
-        lifetime=costs.at["battery storage", "lifetime"],
-    )
+        n.add(
+            "Store",
+            nodes + " li-ion home battery",
+            bus=nodes + " li-ion home battery",
+            location=nodes,
+            e_cyclic=True,
+            e_nom_extendable=True,
+            carrier="li-ion home battery",
+            capital_cost=costs.at["home battery storage", "capital_cost"],
+            lifetime=costs.at["home battery storage", "lifetime"],
+        )
 
-    n.add(
-        "Link",
-        nodes + " home battery charger",
-        bus0=nodes + " low voltage",
-        bus1=nodes + " home battery",
-        carrier="home battery charger",
-        efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
-        capital_cost=costs.at["home battery inverter", "capital_cost"],
-        p_nom_extendable=True,
-        lifetime=costs.at["battery inverter", "lifetime"],
-    )
+        n.add(
+            "Link",
+            nodes + " li-ion home battery charger",
+            bus0=nodes + " low voltage",
+            bus1=nodes + " li-ion home battery",
+            carrier="li-ion home battery charger",
+            efficiency=costs.at["home battery inverter", "efficiency"] ** 0.5,
+            capital_cost=costs.at["home battery inverter", "capital_cost"],
+            p_nom_extendable=True,
+            lifetime=costs.at["home battery inverter", "lifetime"],
+        )
 
-    n.add(
-        "Link",
-        nodes + " home battery discharger",
-        bus0=nodes + " home battery",
-        bus1=nodes + " low voltage",
-        carrier="home battery discharger",
-        efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
-        marginal_cost=costs.at["home battery storage", "marginal_cost"],
-        p_nom_extendable=True,
-        lifetime=costs.at["battery inverter", "lifetime"],
-    )
+        n.add(
+            "Link",
+            nodes + " li-ion home battery discharger",
+            bus0=nodes + " li-ion home battery",
+            bus1=nodes + " low voltage",
+            carrier="li-ion home battery discharger",
+            efficiency=costs.at["home battery inverter", "efficiency"] ** 0.5,
+            marginal_cost=options["marginal_cost_storage"],
+            p_nom_extendable=True,
+            lifetime=costs.at["home battery inverter", "lifetime"],
+        )
+
+    elif "battery" in snakemake.params.electricity["extendable_carriers"]["StorageUnit"]:
+        n.add("Carrier", "li-ion home battery")
+        max_hours = snakemake.params.max_hours
+        for max_hour in max_hours["li-ion battery"]:
+            n.add(
+                "StorageUnit",
+                nodes,
+                suffix=f" li-ion home battery {max_hour}h",
+                bus=nodes + " low voltage",
+                carrier="li-ion home battery",
+                p_nom_extendable=True,
+                capital_cost=costs.at[f"li-ion home battery {max_hour}h", "capital_cost"],
+                marginal_cost=options["marginal_cost_storage"],
+                efficiency_store=costs.at["home battery inverter", "efficiency"] ** 0.5,
+                efficiency_dispatch=costs.at["home battery inverter", "efficiency"] ** 0.5,
+                max_hours=max_hour,
+                cyclic_state_of_charge=True,
+                lifetime=costs.at["home battery storage", "lifetime"],
+            )
 
 
 def insert_gas_distribution_costs(n, costs):
@@ -1526,6 +1630,237 @@ def add_electricity_grid_connection(n, costs):
         "electricity grid connection", "capital_cost"
     ]
 
+def get_salt_caverns(cavern_types, fn_h2_cavern):
+    h2_caverns = pd.read_csv(fn_h2_cavern, index_col=0)
+
+    if (
+        not h2_caverns.empty
+        and options["hydrogen_underground_storage"]
+        and set(cavern_types).intersection(h2_caverns.columns)
+    ):
+        h2_caverns = h2_caverns[cavern_types].sum(axis=1)
+
+        # only use sites with at least 2 TWh potential
+        h2_caverns = h2_caverns[h2_caverns > 2]
+
+        # convert TWh to MWh
+        h2_caverns = h2_caverns * 1e6
+
+        # clip at 1000 TWh for one location
+        h2_caverns.clip(upper=1e9, inplace=True)
+
+        return h2_caverns
+    else:
+        return None
+
+
+def add_storageunits(n, costs, carriers, max_hours, h2_caverns):
+    nodes = pop_layout.index
+
+    # check for not implemented storage technologies
+    implemented = ["H2", "li-ion battery", "iron-air battery", "lfp", "vanadium", "lair", "pair"]
+    not_implemented = list(set(carriers).difference(implemented))
+    available_carriers = list(set(carriers).intersection(implemented))
+    if len(not_implemented) > 0:
+        logger.warning(
+            f"{not_implemented} are not yet implemented as Storage technologies in PyPSA-Eur"
+        )
+    missing_carriers = list(set(available_carriers).difference(n.carriers.index))
+    n.add("Carrier", missing_carriers)
+
+    lookup_store = {"H2": "electrolysis", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery charge",
+    "lfp": "Lithium-Ion-LFP-bicharger", "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-charger", "pair": "Compressed-Air-Adiabatic-bicharger"}
+    lookup_dispatch = {"H2": "fuel cell", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery discharge",
+    "lfp": "Lithium-Ion-LFP-bicharger", "vanadium": "Vanadium-Redox-Flow-bicharger", "lair":  "Liquid-Air-discharger", "pair": "Compressed-Air-Adiabatic-bicharger"}
+
+    for carrier in available_carriers:
+        for max_hour in max_hours[carrier]:
+            roundtrip_correction = 0.5 if carrier == "li-ion battery" else 1
+            if carrier == "H2":
+                # h2_caverns will be empty pd.Series if hydrogen_underground_storage is set to false
+                n.add(
+                    "StorageUnit",
+                    h2_caverns.index,
+                    suffix=f" {carrier} {max_hour}h",
+                    bus=h2_caverns.index,
+                    carrier=carrier,
+                    p_nom_extendable=True,
+                    p_nom_max=h2_caverns.div(max_hour).values,
+                    capital_cost=costs.at[f"H2 underground {max_hour}h", "capital_cost"],
+                    marginal_cost=options["marginal_cost_storage"],
+                    efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
+                    ** roundtrip_correction,
+                    efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
+                    ** roundtrip_correction,
+                    max_hours=max_hour,
+                    cyclic_state_of_charge=True,
+                    lifetime=costs.at["hydrogen storage underground", "lifetime"],
+                )
+                # hydrogen stored overground (where not already underground)
+                nodes_ = h2_caverns.index.symmetric_difference(nodes)
+
+            else:
+                nodes_ = nodes
+
+            cost_carrier = "H2 tank" if carrier == "H2" else carrier
+            cost_carrier = "iron-air battery storage" if carrier == "iron-air battery" else cost_carrier
+            n.add(
+                "StorageUnit",
+                nodes_,
+                suffix=f" {carrier} {max_hour}h",
+                bus=nodes_,
+                carrier=carrier,
+                p_nom_extendable=True,
+                capital_cost=costs.at[f"{cost_carrier} {max_hour}h", "capital_cost"],
+                marginal_cost=options["marginal_cost_storage"],
+                efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
+                ** roundtrip_correction,
+                efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
+                ** roundtrip_correction,
+                max_hours=max_hour,
+                cyclic_state_of_charge=True,
+                lifetime=costs.at[f"{cost_carrier} {max_hour}h", "lifetime"],
+            )
+    
+    logger.info(f"Adding storage_units with carrier {available_carriers}")
+
+
+def add_stores(n, costs, carriers, h2_caverns):
+    nodes = pop_layout.index
+
+    # check for not implemented storage technologies
+    implemented = ["H2", "li-ion battery", "iron-air battery"]
+    not_implemented = list(set(carriers).difference(implemented))
+    available_carriers = list(set(carriers).intersection(implemented))
+    if len(not_implemented) > 0:
+        logger.warning(
+            f"{not_implemented} are not yet implemented as Store technologies in PyPSA-Eur"
+        )
+    missing_carriers = list(set(available_carriers).difference(n.carriers.index))
+    n.add("Carrier", missing_carriers)
+
+    if "H2" in carriers:
+        if h2_caverns is not None:
+            logger.info("Add hydrogen underground storage")
+            h2_capital_cost = costs.at["hydrogen storage underground", "capital_cost"]
+
+            n.add(
+                "Store",
+                h2_caverns.index + " H2 Store",
+                bus=h2_caverns.index + " H2",
+                e_nom_extendable=True,
+                e_nom_max=h2_caverns.values,
+                e_cyclic=True,
+                carrier="H2 Store",
+                capital_cost=h2_capital_cost,
+                lifetime=costs.at["hydrogen storage underground", "lifetime"],
+            )
+            nodes_overground = h2_caverns.index.symmetric_difference(nodes)
+        else:
+            nodes_overground = nodes
+
+        # hydrogen stored overground (where not already underground)
+        h2_capital_cost = costs.at[
+            "hydrogen storage tank type 1 including compressor", "capital_cost"
+        ]
+
+        n.add(
+            "Store",
+            nodes_overground + " H2 Store",
+            bus=nodes_overground + " H2",
+            e_nom_extendable=True,
+            e_cyclic=True,
+            carrier="H2 Store",
+            capital_cost=h2_capital_cost,
+            lifetime=costs.at[
+                "hydrogen storage tank type 1 including compressor", "lifetime"
+            ],
+        )
+
+    if "li-ion battery" in carriers:
+
+        n.add(
+            "Bus", nodes + " li-ion battery", location=nodes, carrier="li-ion battery", unit="MWh_el"
+        )
+
+        n.add(
+            "Store",
+            nodes + " li-ion battery",
+            bus=nodes + " li-ion battery",
+            e_cyclic=True,
+            e_nom_extendable=True,
+            carrier="li-ion battery",
+            capital_cost=costs.at["battery storage", "capital_cost"],
+            lifetime=costs.at["battery storage", "lifetime"],
+        )
+
+        n.add(
+            "Link",
+            nodes + " li-ion battery charger",
+            bus0=nodes,
+            bus1=nodes + " li-ion battery",
+            carrier="li-ion battery charger",
+            efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
+            capital_cost=costs.at["battery inverter", "capital_cost"],
+            p_nom_extendable=True,
+            lifetime=costs.at["battery inverter", "lifetime"],
+        )
+
+        n.add(
+            "Link",
+            nodes + " li-ion battery discharger",
+            bus0=nodes + " li-ion battery",
+            bus1=nodes,
+            carrier="li-ion battery discharger",
+            efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
+            marginal_cost=options["marginal_cost_storage"],
+            p_nom_extendable=True,
+            lifetime=costs.at["battery inverter", "lifetime"],
+        )
+
+    if "iron-air battery" in carriers:
+
+        n.add(
+            "Bus", nodes + " iron-air battery", location=nodes, carrier="iron-air battery", unit="MWh_el"
+        )
+
+        n.add(
+            "Store",
+            nodes + " iron-air battery",
+            bus=nodes + " iron-air battery",
+            e_cyclic=True,
+            e_nom_extendable=True,
+            carrier="iron-air battery",
+            capital_cost=costs.at["iron-air battery", "capital_cost"],
+            lifetime=costs.at["iron-air battery", "lifetime"],
+        )
+
+        # using capex and lifetime from battery inverter for charge/discharge link since it's missing from iron-air data
+        n.add(
+            "Link",
+            nodes + " iron-air battery charger",
+            bus0=nodes,
+            bus1=nodes + " iron-air battery",
+            carrier="iron-air battery charger",
+            efficiency=costs.at["iron-air battery charge", "efficiency"],
+            capital_cost=costs.at["battery inverter", "capital_cost"],
+            p_nom_extendable=True,
+            lifetime=costs.at["battery inverter", "lifetime"],
+        )
+
+        n.add(
+            "Link",
+            nodes + " iron-air battery discharger",
+            bus0=nodes + " iron-air battery",
+            bus1=nodes,
+            carrier="iron-air battery discharger",
+            efficiency=costs.at["iron-air battery discharge", "efficiency"],
+            marginal_cost=options["marginal_cost_storage"],
+            p_nom_extendable=True,
+            lifetime=costs.at["battery inverter", "lifetime"],
+        )
+
+    logger.info(f"Adding stores with carrier {carriers}")
 
 def add_storage_and_grids(
     n,
@@ -1649,55 +1984,6 @@ def add_storage_and_grids(
             marginal_cost=costs.at["OCGT", "VOM"],
             lifetime=costs.at["OCGT", "lifetime"],
         )
-
-    h2_caverns = pd.read_csv(h2_cavern_file, index_col=0)
-
-    if (
-        not h2_caverns.empty
-        and options["hydrogen_underground_storage"]
-        and set(cavern_types).intersection(h2_caverns.columns)
-    ):
-        h2_caverns = h2_caverns[cavern_types].sum(axis=1)
-
-        # only use sites with at least 2 TWh potential
-        h2_caverns = h2_caverns[h2_caverns > 2]
-
-        # convert TWh to MWh
-        h2_caverns = h2_caverns * 1e6
-
-        # clip at 1000 TWh for one location
-        h2_caverns.clip(upper=1e9, inplace=True)
-
-        logger.info("Add hydrogen underground storage")
-
-        h2_capital_cost = costs.at["hydrogen storage underground", "capital_cost"]
-
-        n.add(
-            "Store",
-            h2_caverns.index + " H2 Store",
-            bus=h2_caverns.index + " H2",
-            e_nom_extendable=True,
-            e_nom_max=h2_caverns.values,
-            e_cyclic=True,
-            carrier="H2 Store",
-            capital_cost=h2_capital_cost,
-            lifetime=costs.at["hydrogen storage underground", "lifetime"],
-        )
-
-    # hydrogen stored overground (where not already underground)
-    tech = "hydrogen storage tank type 1 including compressor"
-    nodes_overground = h2_caverns.index.symmetric_difference(nodes)
-
-    n.add(
-        "Store",
-        nodes_overground + " H2 Store",
-        bus=nodes_overground + " H2",
-        e_nom_extendable=True,
-        e_cyclic=True,
-        carrier="H2 Store",
-        capital_cost=costs.at[tech, "capital_cost"],
-        lifetime=costs.at[tech, "lifetime"],
-    )
 
     if options["gas_network"] or options["H2_retrofit"]:
         gas_pipes = pd.read_csv(clustered_gas_network_file, index_col=0)
@@ -1855,43 +2141,11 @@ def add_storage_and_grids(
             lifetime=costs.at["H2 (g) pipeline", "lifetime"],
         )
 
-    n.add("Carrier", "battery")
+    # add stores and storages as specified in the config
+    h2_caverns = get_salt_caverns(cavern_types, h2_cavern_file)
 
-    n.add("Bus", nodes + " battery", location=nodes, carrier="battery", unit="MWh_el")
-
-    n.add(
-        "Store",
-        nodes + " battery",
-        bus=nodes + " battery",
-        e_cyclic=True,
-        e_nom_extendable=True,
-        carrier="battery",
-        capital_cost=costs.at["battery storage", "capital_cost"],
-        lifetime=costs.at["battery storage", "lifetime"],
-    )
-
-    n.add(
-        "Link",
-        nodes + " battery charger",
-        bus0=nodes,
-        bus1=nodes + " battery",
-        carrier="battery charger",
-        efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
-        capital_cost=costs.at["battery inverter", "capital_cost"],
-        p_nom_extendable=True,
-        lifetime=costs.at["battery inverter", "lifetime"],
-    )
-
-    n.add(
-        "Link",
-        nodes + " battery discharger",
-        bus0=nodes + " battery",
-        bus1=nodes,
-        carrier="battery discharger",
-        efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
-        p_nom_extendable=True,
-        lifetime=costs.at["battery inverter", "lifetime"],
-    )
+    add_stores(n, costs, options["extendable_carriers"]["Store"], h2_caverns)
+    add_storageunits(n, costs, options["extendable_carriers"]["StorageUnit"], snakemake.params.max_hours, h2_caverns)
 
     if options["methanation"]:
         n.add(
@@ -5273,6 +5527,7 @@ if __name__ == "__main__":
     update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     options = snakemake.params.sector
+    options["extendable_carriers"] = snakemake.params.electricity.get("extendable_carriers", dict())
     cf_industry = snakemake.params.industry
 
     investment_year = int(snakemake.wildcards.planning_horizons)
@@ -5285,7 +5540,7 @@ if __name__ == "__main__":
 
     costs = prepare_costs(
         snakemake.input.costs,
-        snakemake.params.costs,
+        snakemake.params,
         nyears,
     )
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This pull request cherry picks the core feature used in the project ["The Role of Energy Storage in Germany"](https://github.com/open-energy-transition/form-energy-storage)

**Core changes:**
- Add Iron-Air battery, Lithium iron phosphate (lpf), Vanadium, Liquid-air (lair) and Compressed-air (pair) storage technology
- Storage technologies can be selected in the `rule prepare_sector_network`.
- Change nomenclature for lithium-ion battery storages from ``battery`` to ``li-ion battery``.
- The same technologies can have multiple storage duration.
- Core changes are based on: https://github.com/open-energy-transition/form-energy-storage/pull/1

**Differences in the original version:**
- Compared to the original version, adding storage technologies in the config `electricity: extendable_carriers` will apply those technologies both in the electricity network and the sector-coupled model.
- Storage technologies are year coded as well similar to renewable technologies
- Replace ``battery`` to ``li-ion battery`` in test run config as well.
- Because of this, the `make test` test run works as well.
- Compatible with the current version of OETs PyPSA-Eur

**Minor changes:**
- In the `rule make_summary` and `rule make_summary_perfect`, fix the bug that occurs when no `StorageUnit` is dispatched.

@daniel-rdt @tgilon if you have the spare time, can you check on this for suggestions, and does it make sense right now to upstream this to the master PyPSA-Eur, or only  OETs PyPSA-Eur?

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] A release note `doc/release_notes.rst` is added.
