### PR TITLE
Feature/Annual Matching

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -107,7 +107,7 @@ costs:
   year: 2025
   version: v0.10.1
 
-  overwrite:
+  overwrites:
     fuel:
       OCGT: 38.84 # https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52022SC0230 (Annex)
       CCGT: 38.84
@@ -136,6 +136,8 @@ costs:
     fuel cell: 0.
     li-ion battery: 0.
     battery inverter: 0.
+  capital_cost:
+    geothermal: 10000
   emission_prices:
     enable: false
     co2: 0.
@@ -145,3 +147,18 @@ costs:
 clustering:
   temporal:
     resolution_sector: 3H
+
+# ================ Procurment Metastudy ================
+procurement:
+  stratergy: res100 # "ref", "cfe90", "cfe98", "cfe100", "cfe..", "res90", "res98", "res100", "res.."
+  scope: "country" # "node", "country", "all"
+
+  strip_network: true
+
+  ci:
+    Germany: # Set name here
+      location: "DE0 0"
+
+  technology:
+    generation_tech: ["onwind", "solar", "nuclear", "allam", "geothermal"]
+    storage_tech: ["li-ion battery", "vanadium", "lair", "pair", "iron-air battery"]

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -59,7 +59,7 @@ snapshots:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   retrieve: auto
-  retrieve_databundle: false
+  retrieve_databundle: true
   retrieve_cost_data: true
   build_cutout: false
   retrieve_cutout: false
@@ -151,8 +151,9 @@ clustering:
 # ================ Procurment Metastudy ================
 procurement:
   year: 2030
-  stratergy: res100 # "ref", "cfe90", "cfe98", "cfe100", "cfe..", "res90", "res98", "res100", "res.."
-  scope: "country" # "node", "country", "all"
+  stratergy: res # "ref", "cfe90", "cfe98", "cfe100", "cfe..", "res90", "res98", "res100", "res.."
+  penetration: 100
+  scope: "all" # "node", "country", "all"
 
   strip_network: true # simplify the network to only include the country with CI and it's neighbours
   excess_share: 0.  # share of excess CI generation that can be sold to the grid [percentage]

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -152,7 +152,7 @@ procurement:
   year: 2030
   strategy: vol-match # name of procurement strategy "vol-match"
   scope: "all" # "node", "country", "all"
-  penetration: 100
+  energy_matching: 100
 
   load: data/ci_load.csv # path to CI load input data
   profile: "industry" # type of load profile (e.g., "baseload", "industry")

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -21,10 +21,10 @@ remote:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: ""
-  name: "baseline-3H"
+  name: "baseline-3H-storage"
   scenarios:
-    enable: false
-    file: config/scenarios.yaml
+    enable: true
+    file: config/scenarios.meta.yaml
   disable_progressbar: false
   shared_resources:
     policy: false
@@ -59,13 +59,12 @@ snapshots:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   retrieve: auto
-  retrieve_databundle: true
+  retrieve_databundle: false
   retrieve_cost_data: true
   build_cutout: false
-  retrieve_cutout: true
+  retrieve_cutout: false
   custom_busmap: false
   drop_leap_day: true
-  sector: false
   procurement: true  # [true, false ] If true, model the procurement strategies
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#electricity
@@ -79,8 +78,8 @@ electricity:
     iron-air battery: [100]
 
   extendable_carriers:
-    StorageUnit: [li-ion battery, iron-air battery, vanadium, lair, pair] # 
-    Store: [H2]
+    StorageUnit: [] # li-ion battery, iron-air battery, H2, lfp, vanadium, lair, pair
+    Store: [li-ion battery, H2]
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
@@ -164,8 +163,8 @@ procurement:
       location: "DE0 0"
 
   technology:
-    generation_tech: ["onwind", "solar", "nuclear", "allam", "geothermal"]
-    storage_tech: ["li-ion battery", "vanadium", "lair", "pair", "iron-air battery"]
+    generation_tech: ["onwind", "solar", "allam", "geothermal"]  # "nuclear"
+    storage_tech: ["li-ion battery"] # "iron-air battery"
 
   strip_network: true # [ true, false ] If true, model only the countries with the CI loads and their neighbors
   excess_share: 0.  # share of excess CI generation that can be sold to the grid [percentage]

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -150,10 +150,13 @@ clustering:
 
 # ================ Procurment Metastudy ================
 procurement:
+  year: 2030
   stratergy: res100 # "ref", "cfe90", "cfe98", "cfe100", "cfe..", "res90", "res98", "res100", "res.."
   scope: "country" # "node", "country", "all"
 
-  strip_network: true
+  strip_network: true # simplify the network to only include the country with CI and it's neighbours
+  excess_share: 0.  # share of excess CI generation that can be sold to the grid [percentage]
+  min_iterations: 2
 
   ci:
     Germany: # Set name here

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -51,7 +51,7 @@ vol-match-3H-DE:
   procurement:
     strategy: vol-match
     scope: "all"
-    penetration: 100
+    energy_matching: 100
     participation: 10
 
     ci:
@@ -64,7 +64,7 @@ vol-match-3H-DE-FR-IT:
   procurement:
     strategy: vol-match
     scope: "all"
-    penetration: 100
+    energy_matching: 100
     participation: 10
 
     ci:

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -29,7 +29,7 @@ baseline-1H:
 baseline-3H-noline:
   scenario:
     ll:
-      - v1.0
+    - v1.0
   enable:
     procurement: false
 

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+
+# This file is used to define the scenarios that are run by snakemake. Each entry on the first level is a scenario. Each scenario can contain configuration overrides with respect to the config/config.yaml settings.
+#
+# Example
+#
+# custom-scenario: # name of the scenario
+#   electricity:
+#       renewable_carriers: [wind, solar] # override the list of renewable carriers
+
+# ======== Baseline model without procurement ========
+# ====================================================
+
+baseline-3H:
+  enable:
+    procurement: false
+
+baseline-1H:
+  enable:
+    procurement: false
+
+  clustering:
+    temporal:
+      resolution_sector: 1H
+
+baseline-3H-noline:
+  scenario:
+    ll:
+      - v1.0
+  enable:
+    procurement: false
+
+  transmission_projects:
+    enable: false
+
+baseline-3H-storage:
+  enable:
+    procurement: false
+
+  electricity:
+    StorageUnit: [li-ion battery, iron-air battery, vanadium, lair, pair] # 
+    Store: [H2]
+
+# ======== Baseline model with volume matching ========
+# =====================================================
+
+vol-match-3H-DE:
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    penetration: 100
+    participation: 10
+
+    ci:
+      Germany:
+        location: "DE0 0"
+
+    strip_network: false
+
+vol-match-3H-DE-FR-IT:
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    penetration: 100
+    participation: 10
+
+    ci:
+      Germany:
+        location: "DE0 0"
+      France:
+        location: "FR0 0"
+      Italy:
+        location: "IT0 0"
+
+    strip_network: false

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -120,6 +120,12 @@ rule solve_sector_network_myopic:
         co2_sequestration_potential=config_provider(
             "sector", "co2_sequestration_potential", default=200
         ),
+        # ================ New Params Start ================
+        procurement_enable=config_provider("enable", "procurement"),
+        procurement=config_provider("procurement"),
+        costs=config_provider("costs"),
+        max_hours=config_provider("electricity", "max_hours"),
+        # ================  New Params End  ================
         custom_extra_functionality=input_custom_extra_functionality,
     input:
         network=resources(

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1162,7 +1162,7 @@ def res_annual_matching_constraints(n):
     The total generation from all CI-related generators (renewable carriers) and links (conventional/clean carriers) must equal to its own load consumption.
     """
     weights = n.snapshot_weightings["generators"]
-    penetration = n.config["procurement"]["penetration"] / 100
+    energy_matching = n.config["procurement"]["energy_matching"] / 100
 
     for name in n.config["procurement"]["ci"]:
         gen_ci = list(n.generators.query("ci == @name").index)
@@ -1180,7 +1180,7 @@ def res_annual_matching_constraints(n):
 
         # Note equality sign
         n.model.add_constraints(
-            lhs == penetration * total_load, name=f"RES_annual_matching_{name}"
+            lhs == energy_matching * total_load, name=f"RES_annual_matching_{name}"
         )
 
 
@@ -1196,7 +1196,7 @@ def excess_constraints(n):
         total_load = (n.loads_t.p_set[name + " load"] * weights).sum()
         share = n.config["procurement"][
             "excess_share"
-        ]  # 'sliding': max(0., penetration - 0.8)
+        ]  # 'sliding': max(0., energy_matching - 0.8)
 
         n.model.add_constraints(
             excess <= share * total_load, name=f"Excess_constraint_{name}"
@@ -1288,11 +1288,11 @@ def extra_functionality(
     ):
         procurement = config["procurement"]
         strategy = procurement["strategy"]
-        penetration = procurement["penetration"]
+        energy_matching = procurement["energy_matching"]
         res_capacity_constraints(n)
 
         if strategy == "vol-match":
-            logger.info(f"Setting annual RES target of {penetration}%")
+            logger.info(f"Setting annual RES target of {energy_matching}%")
             res_annual_matching_constraints(n)
             excess_constraints(n)
         else:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1292,7 +1292,7 @@ def extra_functionality(
         procurement = config["procurement"]
         strategy = procurement["strategy"]
         penetration = procurement["penetration"]
-        #res_capacity_constraints(n) TODO: not yet operational
+        # res_capacity_constraints(n) TODO: not yet operational
 
         if strategy == "vol-match":
             logger.info(f"Setting annual RES target of {penetration}")


### PR DESCRIPTION
Closes #4

## Changes proposed in this Pull Request

This pull request adds C&I and includes all the technologies that can be procured. The annual volume matching is now included in the model as a constraints.

TODO: Renewable capacity constraints need some improvements before pushing this.

## Configuration settings
We added a new key `procurement`, which allows to define:

- `year`: The year in which the procurement strategy is activated
- `scope`: The spatial scope of the procurement options for renewable onshore wind and solar.
-  `technology`: list of technologies independent from the wider grid that C&I can invest in.
- `excess_share`: share of excess CI generation that can be sold to the grid [percentage]
- `min_iterations`: number of iterations that are conducted to reach stability (important for 247-cfe strategy)

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
