### PR TITLE
Add Emission-matching constraint and retrieve CI load share from Eurostat

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -150,9 +150,10 @@ clustering:
 # ================ Procurment Metastudy ================
 procurement:
   year: 2030
-  strategy: vol-match # name of procurement strategy "vol-match"
+  strategy: emi-match # name of procurement strategy: vol-match, emi-match, 24-7 cfe
   scope: "all" # "node", "country", "all"
   energy_matching: 100 # share of CI energy demand to be procured
+  emission_matching: 100 # share of CI emissions to be compensated
 
   load:
     load_path: data/CI-load.csv # path to CI load input data (from https://ec.europa.eu/eurostat/databrowser/view/nrg_cb_e__custom_16270810/default/table?lang=en (CSV 2.0))

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -21,7 +21,7 @@ remote:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: ""
-  name: "baseline-3H"
+  name: "baseline-3H-emi-match"
   scenarios:
     enable: false
     file: config/scenarios.meta.yaml
@@ -44,7 +44,7 @@ scenario:
   sector_opts:
   - ''
   planning_horizons:
-  - 2025
+  # - 2025
   - 2030
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -21,9 +21,9 @@ remote:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: ""
-  name: "baseline-3H-storage"
+  name: "baseline-3H"
   scenarios:
-    enable: true
+    enable: false
     file: config/scenarios.meta.yaml
   disable_progressbar: false
   shared_resources:
@@ -152,11 +152,13 @@ procurement:
   year: 2030
   strategy: vol-match # name of procurement strategy "vol-match"
   scope: "all" # "node", "country", "all"
-  energy_matching: 100
+  energy_matching: 100 # share of CI energy demand to be procured
 
-  load: data/ci_load.csv # path to CI load input data
-  profile: "industry" # type of load profile (e.g., "baseload", "industry")
-  participation: 10 # share of CI load participating to the procurement
+  load:
+    load_path: data/CI-load.csv # path to CI load input data (from https://ec.europa.eu/eurostat/databrowser/view/nrg_cb_e__custom_16270810/default/table?lang=en (CSV 2.0))
+    load_year: 2023 
+    profile: "industry" # type of load profile (e.g., "baseload", "industry")
+    participation: 10 # share of CI load participating to the procurement
 
   ci:
     Germany: # Set name here

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1236,7 +1236,7 @@ def emission_matching_constraints(n):
         total_emissions = participation * (n.loads_t.p_set[name + " load"] * weights * moer).sum()
         
         n.model.add_constraints(
-            lhs == total_emissions, name=f"emission_matching_{name}"
+            lhs >= total_emissions, name=f"emission_matching_{name}"
         )
 
 def extra_functionality(

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1581,7 +1581,17 @@ def load_profile(
         load = 0.0
     else:
         country = n.buses.country[location]
-        data = pd.read_csv(load["load_path"])
+        
+        import requests
+        url = "https://ec.europa.eu/eurostat/api/dissemination/sdmx/3.0/data/dataflow/ESTAT/nrg_cb_e/1.0/*.*.*.*.*?c[freq]=A&c[nrg_bal]=FC,FC_IND_E,FC_OTH_CP_E&c[siec]=E7000&c[unit]=GWH&c[geo]=EU27_2020,EA20,BE,BG,CZ,DK,DE,EE,IE,EL,ES,FR,HR,IT,CY,LV,LT,LU,HU,MT,NL,AT,PL,PT,RO,SI,SK,FI,SE,IS,LI,NO,UK,BA,ME,MD,MK,GE,AL,RS,TR,UA,XK&c[TIME_PERIOD]=2023,2022,2021,2020&compress=false&format=csvdata&formatVersion=2.0&lang=en&labels=name"
+        try:
+            response = requests.get(url)
+            with open(load["load_path"], "wb") as file:
+                file.write(response.content)
+            data = pd.read_csv(load["load_path"])
+        except requests.ConnectionError:
+            logger.warning("No internet connection. Reading data from the local file.")
+            data = pd.read_csv(load["load_path"])
         
         # Ensure data for the specified year exists for all countries
         years = list(data["TIME_PERIOD"].unique())

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1594,23 +1594,27 @@ def load_profile(
             data = pd.read_csv(load["load_path"])
         
         # Ensure data for the specified year exists for all countries
+        data["reference_year"] = int(load["load_year"])
         years = list(data["TIME_PERIOD"].unique())
+        years.reverse()
         for geo in data["geo"].unique():
             if not ((data["TIME_PERIOD"] == int(load["load_year"])) & (data["geo"] == geo)).any():
-                for fallback_year in years[:-1]:
+                for fallback_year in years[1:]:
                     if ((data["TIME_PERIOD"] == fallback_year) & (data["geo"] == geo)).any():
                         fallback_row = data[(data["TIME_PERIOD"] == fallback_year) & (data["geo"] == geo)].copy()
                         fallback_row["TIME_PERIOD"] = int(load["load_year"])
                         data = pd.concat([data, fallback_row], ignore_index=True)
+                        data.loc[(data["TIME_PERIOD"] == int(load["load_year"])) & (data["geo"] == geo), "reference_year"] = fallback_year
                         break
         
         filtered_data = data[(data["TIME_PERIOD"] == int(load["load_year"])) & (data["geo"] == country)]
         industrial_consumption = filtered_data[filtered_data["nrg_bal"] == "FC_IND_E"]["OBS_VALUE"].values[0]
         commercial_consumption = filtered_data[filtered_data["nrg_bal"] == "FC_OTH_CP_E"]["OBS_VALUE"].values[0]
         total_consumption = filtered_data[filtered_data["nrg_bal"] == "FC"]["OBS_VALUE"].values[0]
-
         share = (industrial_consumption + commercial_consumption) / total_consumption # (-)
         load_year = share * (n.loads_t.p_set[location]*n.snapshot_weightings.objective).sum() # MWh
+        logger.info(f"CI load in {country} (raw data from Eurostat):\nannual consumption: {round((industrial_consumption + commercial_consumption)/1000)} TWh\nreference year: {filtered_data['reference_year'].values[0]}\nshare: {round(share*100,0)}%")
+        logger.info(f"CI load in {country} (PyPSA data):\nannual consumption {round(load_year/10**6)} TWh\nreference year: {load["load_year"]}")
         load = load_year / 8760 * load["participation"] / 100 # MW
 
     load_day = load * 24 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This pull request includes two main updates:

1. A first version of the emission-matching constraint is included based on the WattTime demo. The emission factor of natural gas is used  as a placeholder for the marginal operation emission rates (MOERs).
2. The CI load input data are now directly retrieved from [Eurostat database](https://ec.europa.eu/eurostat/databrowser/view/nrg_cb_e__custom_16270810/default/table?lang=en). Then, the resulting CI share over the final electricity consumption is applied to the PyPSA-Eur load input data for consistency reasons.

Note: the WattTime demo will be included in the documentation.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
