### PR TITLE
add coal phaseout through powerplants_filter

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -21,7 +21,7 @@ remote:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   prefix: ""
-  name: "vol-match-3H-IT"
+  name: "baseline-3H"
   scenarios:
     enable: true
     file: config/scenarios.meta.yaml
@@ -81,6 +81,11 @@ electricity:
     StorageUnit: [] # li-ion battery, iron-air battery, H2, lfp, vanadium, lair, pair
     Store: [li-ion battery, H2]
 
+  powerplants_filter: >
+    (DateOut >= 2024 or DateOut != DateOut) and not (Country == 'DE' and Fueltype == 'Nuclear')
+    and not (Country.isin(['AT', 'BE', 'DK', 'ES', 'FI', 'FR', 'GB', 'GR', 'HU', 'IE', 'IT', 'MK', 'NL', 'PT', 'RS', 'SE', 'SK'])
+    and Fueltype.isin(['Hard Coal', 'Lignite']))
+
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
   transport: false
@@ -103,7 +108,7 @@ sector:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#costs
 costs:
-  year: 2025
+  year: 2030
   version: v0.10.1
 
   overwrites:

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -86,6 +86,13 @@ electricity:
     and not (Country.isin(['AT', 'BE', 'DK', 'ES', 'FI', 'FR', 'GB', 'GR', 'HU', 'IE', 'IT', 'MK', 'NL', 'PT', 'RS', 'SE', 'SK'])
     and Fueltype.isin(['Hard Coal', 'Lignite']))
 
+  transmission_limit: v1.0
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#transmission_projects
+transmission_projects:
+  include:
+    nep: false
+
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
   transport: false
@@ -113,13 +120,11 @@ costs:
 
   overwrites:
     fuel:
-      OCGT: 38.84 # https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52022SC0230 (Annex)
-      CCGT: 38.84
-      gas: 38.84
-      coal: 24.57 # https://businessanalytiq.com/procurementanalytics/index/subbituminous-coal-price-index/
-      lignite: 22.11 # https://businessanalytiq.com/procurementanalytics/index/lignite-coal-price-index/
-      nuclear: 1.75 # https://markets.businessinsider.com/commodities/uranium-price
-      uranium: 1.75
+      OCGT: 31.98 # https://tradingeconomics.com/commodity/eu-natural-gas
+      CCGT: 31.98
+      gas: 31.98
+      coal: 10.08 # https://www.tradingview.com/symbols/ICEEUR-ATW1!/ 1 USD = 0.88 EUR
+      lignite: 22.11 # https://www.tradingview.com/symbols/ICEEUR-ATW1!/ 1 USD = 0.88 EUR, lignite ≈ 1/3 hard coal
     efficiency:
       Compressed-Air-Adiabatic-bicharger: 0.7745
     investment:
@@ -129,7 +134,6 @@ costs:
     lifetime:
       Compressed-Air-Adiabatic-store: 40  # years
       Compressed-Air-Adiabatic-bicharger: 40  # years
-
   marginal_cost:
     solar: 0.01
     onwind: 0.015
@@ -144,7 +148,7 @@ costs:
     geothermal: 10000
   emission_prices:
     enable: false
-    co2: 0.
+    co2: 64.85
     co2_monthly_prices: false
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#clustering

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -18,6 +18,13 @@ baseline-3H:
   enable:
     procurement: false
 
+baseline-3H-nores-target:
+  enable:
+    procurement: false
+
+  procurement:
+    res_target: false
+
 baseline-1H:
   enable:
     procurement: false
@@ -25,13 +32,6 @@ baseline-1H:
   clustering:
     temporal:
       resolution_sector: 1H
-
-baseline-3H-v1.0:
-  enable:
-    procurement: false
-
-  electricity:
-    transmission_limit: v1.0
 
 baseline-3H-storage:
   enable:

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -26,15 +26,12 @@ baseline-1H:
     temporal:
       resolution_sector: 1H
 
-baseline-3H-noline:
-  scenario:
-    ll:
-    - v1.0
+baseline-3H-v1.0:
   enable:
     procurement: false
 
-  transmission_projects:
-    enable: false
+  electricity:
+    transmission_limit: v1.0
 
 baseline-3H-storage:
   enable:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -597,6 +597,7 @@ def calculate_grid_score(
     )
     all_p = pd.concat([df_gen_total, -df_link_total], axis=1).T.groupby(level=0).sum().T
 
+    n.buses_t[f"{name}_all_p"] = all_p
     n.buses_t[f"{name}_score"] = n.buses_t[f"{name}_p"] / all_p
     n.buses[f"{name}_score"] = (weights @ n.buses_t[f"{name}_p"]) / (weights @ all_p)
 
@@ -1285,7 +1286,7 @@ def ember_res_target(n):
             df[
                 df[bus_col].isin(bus_list)
                 & ~df["carrier"].isin(grid_carriers)
-                & df["ci"].isin([np.NaN, ""])
+                & (df["ci"].isin([np.NaN, ""]) if "ci" in df.columns else True)
             ]
             .copy()
             .assign(country=lambda d: d[bus_col].map(n.buses["country"]))
@@ -1599,6 +1600,9 @@ def extra_functionality(
         custom_extra_functionality = getattr(module, module_name)
         custom_extra_functionality(n, snapshots, snakemake)  # pylint: disable=E0601
 
+    if config["procurement"].get("res_target", False):
+        ember_res_target(n)
+
     if (
         n.params.procurement_enable
         and str(n.params.procurement["year"]) == planning_horizons
@@ -1608,9 +1612,6 @@ def extra_functionality(
         energy_matching = procurement["energy_matching"]
         emission_matching = procurement["emission_matching"]
         res_capacity_constraints(n)
-
-        if procurement["res_target"]:
-            ember_res_target(n)
 
         if strategy == "vol-match":
             logger.info(f"Setting annual volume matching of {energy_matching}%")

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1600,7 +1600,9 @@ def extra_functionality(
         custom_extra_functionality = getattr(module, module_name)
         custom_extra_functionality(n, snapshots, snakemake)  # pylint: disable=E0601
 
-    if config["procurement"].get("res_target", False):
+    if (config["procurement"].get("res_target", False)
+        and str(n.params.procurement["year"]) == planning_horizons
+    ):
         ember_res_target(n)
 
     if (


### PR DESCRIPTION
## Changes proposed in this Pull Request

This pull request added a feature to filter out coal power plants from countries that have a phaseout target of 2030 or earlier. Source: [Beyond Fossil Fuels](https://beyondfossilfuels.org/europes-coal-exit/)

| Country               | Coal Phaseout |     | Country               | Coal Phaseout   |
|-----------------------|---------|-----|-----------------------|---------|
| Albania               | No coal mix  |     | Ireland                    | 2025   |
| Austria                | 2020 |                  | Italy                         | 2028   |
| Belgium              | 2016 |                  | Latvia                      | No coal mix   |
| Bosnia and Herzegovina| -      |      | Lithuania                | No coal mix   |
| Bulgaria              | 2038 |                  | Luxembourg          | No coal mix   |
| Switzerland        | No coal mix  |     | Montenegro          | 2035   |
| Czech Republic  | 2033 |                  | North Macedonia | 2030   |
| Germany             | 2038 |                  | Netherlands          | 2029   |
| Denmark             | 2028 |                  | Norway                  | No coal mix  |
| Estonia                 | No coal mix |     | Poland                    | -   |
| Spain                    | 2025 |                  | Portugal                 | 2021   |
| Finland                 | 2029 |                  | Romania                | 2032   |
| France                  | 2027 |                  | Serbia                     | Under discussion  |
| United Kingdom | 2024 |                 | Slovenia                  | 2033  |
| Greece                  | 2026 |                 | Slovakia                  | 2025  |
| Croatia                  | 2033 |                 | Sweden                  | 2020   |
| Hungary               | 2027 |                 | Kosovo                   | -   |


There are also a few additional minor adjustments:
- In the baseline scenario, the `ember_res_target()` function can be activated independently of the `procurement` setting.  
- Transmission limits have been redefined based on the updated configuration, which may serve as the new base model.  

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
