### PR TITLE
Bugfix: Fix RE capacity constraints and add `res_additionality`

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -183,6 +183,7 @@ procurement:
   min_iterations: 2
 
   res_target: "both" # [ "EU", "country", "both", false ]
+  res_additionality: true # select if the procured renewables are part of the RE target (false) or are in addition to it (true).
 
   grid_policy:
     renewable_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop"]


### PR DESCRIPTION
## Changes proposed in this Pull Request
In the current process, `res_capacity_constraints(n)` and `ember_res_target(n)` incorrectly exclude renewable sources already present in the nodes when calculating the maximum capacity. This bugfix temporarily renames the buses from their CI names to the corresponding node locations (e.g., "Germany" becomes "DE0 0") to resolve the issue.

Additionally, a new flag, `res_additionality`, is introduced to determine whether the procured renewables should count toward the renewable energy target (`False`) or be considered additional to it (`True`).

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
