### PR TITLE
Add renewable capacity targets and bugfix

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -65,6 +65,7 @@ enable:
   build_cutout: false
   retrieve_cutout: true
   drop_leap_day: true
+  procurement: false
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#co2-budget
 co2_budget:
@@ -1060,3 +1061,5 @@ solving:
   mem_mb: 30000 #memory in MB; 20 GB enough for 50+B+I+H2; 100 GB for 181+B+I+H2
   memory_logging_frequency: 30 # in seconds
   runtime: 6h #runtime in humanfriendly style https://humanfriendly.readthedocs.io/en/latest/
+
+procurement: {}

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -44,7 +44,7 @@ scenario:
   sector_opts:
   - ''
   planning_horizons:
-  - 2025
+  #- 2025
   - 2030
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -23,7 +23,7 @@ run:
   prefix: ""
   name: "baseline-3H"
   scenarios:
-    enable: false
+    enable: true
     file: config/scenarios.meta.yaml
   disable_progressbar: false
   shared_resources:
@@ -171,9 +171,9 @@ procurement:
     profile: "industry" # type of load profile (e.g., "baseload", "industry")
     participation: 10 # share of CI load participating to the procurement
 
-  ci:
-    Germany: # Set name here
-      location: "DE0 0"
+  #ci:
+  #  Germany: # Set name here
+  #    location: "DE0 0"
 
   technology:
     generation_tech: ["onwind", "solar", "allam", "geothermal"]  # "nuclear"
@@ -184,6 +184,7 @@ procurement:
   min_iterations: 2
 
   res_target: "both" # [ "EU", "country", "both", false ]
+  res_cap_target: false
   res_additionality: true # select if the procured renewables are part of the RE target (false) or are in addition to it (true).
 
   grid_policy:

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -44,7 +44,6 @@ scenario:
   sector_opts:
   - ''
   planning_horizons:
-  #- 2025
   - 2030
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
@@ -183,8 +182,8 @@ procurement:
   excess_share: 0.  # share of excess CI generation that can be sold to the grid [percentage]
   min_iterations: 2
 
-  res_target: "both" # [ "EU", "country", "both", false ]
-  res_cap_target: false
+  res_target: "EU" # [ "EU", "country", "both", false ]
+  res_cap_target: true
   res_additionality: true # select if the procured renewables are part of the RE target (false) or are in addition to it (true).
 
   grid_policy:

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -156,6 +156,17 @@ clustering:
     resolution_sector: 3H
 
 # ================ Procurment Metastudy ================
+res_target:
+  EU_share_target: true
+  country_share_target: false
+  country_cap_target: true
+  res_additionality: false # select if the procured renewables are part of the RE target (false) or are in addition to it (true).
+
+grid_policy:
+  renewable_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop"]
+  clean_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop", "nuclear", "allam"]
+  emitters: ["CCGT", "OCGT", "coal", "lignite", "oil"]
+
 procurement:
   year: 2030
   strategy: vol-match # name of procurement strategy: vol-match, emi-match, 247-cfe
@@ -181,12 +192,3 @@ procurement:
   strip_network: false # [ true, false ] If true, model only the countries with the CI loads and their neighbors
   excess_share: 0.  # share of excess CI generation that can be sold to the grid [percentage]
   min_iterations: 2
-
-  res_target: "EU" # [ "EU", "country", "both", false ]
-  res_cap_target: true
-  res_additionality: true # select if the procured renewables are part of the RE target (false) or are in addition to it (true).
-
-  grid_policy:
-    renewable_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop"]
-    clean_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop", "nuclear", "allam"]
-    emitters: ["CCGT", "OCGT", "coal", "lignite", "oil"]

--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -44,6 +44,7 @@ scenario:
   sector_opts:
   - ''
   planning_horizons:
+  # - 2025
   - 2030
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1449,6 +1449,9 @@ def ember_res_target(n):
             res_sus = n.model["StorageUnit-p_nom"].rename({"StorageUnit-ext": "StorageUnit"}).loc[res_ext_sus.index]
             res_country += res_sus.groupby(res_ext_sus.country).sum()
 
+        # If the existing capacities exceed the target capacities, set the target equal to the existing capacities
+        country_target_capacity = country_target_capacity.where(res_exist_country <= country_target_capacity, res_exist_country)
+
         n.model.add_constraints(
             res_country + res_exist_country == country_target_capacity,
             name="country_res_cap_constraint"

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1379,7 +1379,7 @@ def ember_res_target(n):
         res_eu = res_gen.sum() + res_link.sum() + res_sus.sum()
 
         n.model.add_constraints(
-            res_eu == (eu_target / 100) * all_eu, name="EU_res_constraint"
+            res_eu >= (eu_target / 100) * all_eu, name="EU_res_constraint"
         )
 
     # --- Country-level RES target constraint ---
@@ -1427,7 +1427,7 @@ def ember_res_target(n):
         )
 
         n.model.add_constraints(
-            res_country == (country_target / 100) * all_country,
+            res_country >= (country_target / 100) * all_country,
             name="country_res_constraint",
         )
 
@@ -1495,7 +1495,7 @@ def ember_res_target(n):
         )
 
         n.model.add_constraints(
-            res_country + res_exist_country == country_target_capacity,
+            res_country + res_exist_country >= country_target_capacity,
             name="country_res_cap_constraint",
         )
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

- **New**: Incorporate renewable energy (RE) targets based on installed capacity using data from the same EMBER source. Since capacity targets are consistently available across all countries, they offer a more reliable basis than national RE share targets. Additionally, capacity-based targets typically result in lower curtailment due to higher renewable generation systems in certain countries than the one that would be prescribed by national RE share targets.

- **New**: Introduce a parameter `res_additionality` to specify whether the procured renewables contribute to the RE target (false) or are considered additional to it (true).

- **Bugfix**: Ensure storage_units are included in the calculation of both renewable share and capacity targets. This adjustment allows large existing hydro capacities to be accounted for, which helps to reduce overall curtailment.

- **Data cleanup**: reformat `res_target` and `grid_policy` configurations to be independent from the procurement config

- **Final decision**: Use only RE capacity targets and the EU-level RE share target in scenario analyses.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
