### PR TITLE
include impact of neighbouring countries grid score, improve ember re…

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -186,6 +186,7 @@ res_target:
   country_share_target: false
   country_cap_target: true
   res_additionality: false # select if the procured renewables are part of the RE target (false) or are in addition to it (true).
+  res_path: data/ember_2030_res_targets.xlsx # path to EMBER 2030 global renewable target data (from https://storage.googleapis.com/emb-prod-bkt-publicdata/public-downloads/res_tracker/outputs/targets_download.xlsx)
 
 grid_policy:
   renewable_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop"]

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -65,6 +65,27 @@ vol-match-DE-3H:
       Germany:
         location: "DE0 0"
 
+vol-match-add-DE-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Germany:
+        location: "DE0 0"
+
 vol-match-FR-3H:
   enable:
     procurement: true
@@ -72,6 +93,27 @@ vol-match-FR-3H:
   electricity:
    ci_load:
       profile: "total"
+
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      France:
+        location: "FR0 0"
+
+vol-match-add-FR-3H:
+  enable:
+    procurement: true
+  
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
 
   procurement:
     strategy: vol-match
@@ -101,6 +143,27 @@ vol-match-ES-3H:
       Spain:
         location: "ES0 0"
 
+vol-match-add-ES-3H:
+  enable:
+    procurement: true
+  
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Spain:
+        location: "ES0 0"
+
 vol-match-DK-3H:
   enable:
     procurement: true
@@ -119,6 +182,27 @@ vol-match-DK-3H:
       Denmark:
         location: "DK0 0"
 
+vol-match-add-DK-3H:
+  enable:
+    procurement: true
+  
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Denmark:
+        location: "DK0 0"
+
 vol-match-IE-3H:
   enable:
     procurement: true
@@ -126,6 +210,27 @@ vol-match-IE-3H:
   electricity:
    ci_load:
       profile: "total"
+
+  procurement:
+    strategy: vol-match
+    scope: "all"
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Ireland:
+        location: "IE3 0"
+
+vol-match-add-IE-3H:
+  enable:
+    procurement: true
+  
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
 
   procurement:
     strategy: vol-match
@@ -168,3 +273,241 @@ vol-match-PL-DE-FR-ES-DK-IE-3H:
         location: "DK0 0"
       Ireland:
         location: "IE3 0"
+
+# ======== Baseline model with 247 CFE matching ========
+# ======================================================
+
+247-cfe-PL-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Poland:
+        location: "PL0 0"
+
+247-cfe-add-PL-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Poland:
+        location: "PL0 0"
+
+247-cfe-DE-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Germany:
+        location: "DE0 0"
+
+247-cfe-add-DE-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Germany:
+        location: "DE0 0"
+
+247-cfe-FR-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      France:
+        location: "FR0 0"
+
+247-cfe-add-FR-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      France:
+        location: "FR0 0"
+
+247-cfe-ES-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Spain:
+        location: "ES0 0"
+
+247-cfe-add-ES-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Spain:
+        location: "ES0 0"
+
+247-cfe-DK-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Denmark:
+        location: "DK0 0"
+
+247-cfe-add-DK-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Denmark:
+        location: "DK0 0"
+
+247-cfe-IE-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Ireland:
+        location: "IE3 0"
+
+247-cfe-add-IE-3H:
+  enable:
+    procurement: true
+
+  electricity:
+   ci_load:
+      profile: "total"
+
+  res_target:
+    res_additionality: true
+
+  procurement:
+    strategy: 247-cfe
+    scope: node
+    energy_matching: 100
+    participation: 70
+
+    ci:
+      Ireland:
+        location: "IE3 0"
+        

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -623,12 +623,51 @@ def calculate_grid_score(
         n.buses_t[f"{name}_score"] = pd.DataFrame(
             0, index=n.snapshots, columns=grid_buses
         )
+        n.buses_t[f"{name}_lvl_score"] = pd.DataFrame(
+            0, index=n.snapshots, columns=grid_buses
+        )
         logger.info(f"{name}_score currently is empty")
+        return
     else:
         global_score = round(
             (weights @ n.buses_t[f"{name}_p"]).sum() / (weights @ all_p).sum() * 100, 2
         )
         logger.info(f"The average {name}_score is: {global_score}%")
+
+    # ===================== Add impact of interconnection =====================
+    # =========================================================================
+
+    def process_time_series(df, static_df, carrier=None, source_bus="bus0"):
+
+        if carrier:
+            df = df.loc[:, static_df.carrier == carrier]
+            
+        clipped_df = df.clip(lower=0).copy()
+    
+        dest_bus = "bus0" if source_bus == "bus1" else "bus1"
+        
+        clipped_df.columns = pd.MultiIndex.from_tuples(
+            [(static_df.loc[col, source_bus], static_df.loc[col, dest_bus]) for col in clipped_df.columns],
+            names=["source", "dest"]
+        )
+        
+        return clipped_df
+    
+    # Process lines and links
+    line_imp_subsetA = process_time_series(n.lines_t.p1, n.lines)
+    line_imp_subsetB = process_time_series(n.lines_t.p0, n.lines, source_bus = "bus1")
+    links_imp_subsetA = process_time_series(n.links_t.p1, n.links, carrier="DC")
+    links_imp_subsetB = process_time_series(n.links_t.p0, n.links, carrier="DC", source_bus = "bus1")
+    
+    df = pd.concat([line_imp_subsetA,line_imp_subsetB,links_imp_subsetA,links_imp_subsetB], axis=1)
+    df = df.T.groupby(["source","dest"]).sum().T
+    
+    clean_import = df.T.mul(n.buses_t[f"{name}_score"].T, level=0).groupby("dest").sum().T
+    all_import = df.T.groupby("dest").sum().T
+    
+    n.buses_t[f"{name}_lvl_score"] = (n.buses_t[f"{name}_p"] + clean_import) / (n.buses_t[f"{name}_all_p"] + all_import)
+    n.buses[f"{name}_lvl_score"] = (weights @ (n.buses_t[f"{name}_p"] + clean_import)) / (weights @ (n.buses_t[f"{name}_all_p"] + all_import))
+
 
 
 def add_CCL_constraints(
@@ -1274,6 +1313,29 @@ def res_capacity_constraints(n):
 
         n.model.add_constraints(gen <= p_nom_max, name=f"RES_capacity-{carrier}")
 
+def retrieve_ember_data(config):
+    file_path = config["res_target"]["res_path"]
+
+    # 1 EUROSTAT data in GWh
+    import requests
+    import os
+    url = "https://storage.googleapis.com/emb-prod-bkt-publicdata/public-downloads/res_tracker/outputs/targets_download.xlsx"
+    
+    if os.path.exists(file_path):
+        data = pd.read_excel(file_path, sheet_name="capacity_target_wide")
+    else:
+        try:
+            response = requests.get(url)
+            logger.info("Downloading EMBER 2030 global renewable target data")
+            with open(file_path, "wb") as file:
+                file.write(response.content)
+            data = pd.read_excel(file_path, sheet_name="capacity_target_wide")
+        except requests.ConnectionError:
+            logger.warning("No internet connection and file not found locally.")
+            raise FileNotFoundError(f"File {file_path} not found and cannot download from the internet.")
+        
+    return data
+
 
 def ember_res_target(n):
     """
@@ -1284,10 +1346,7 @@ def ember_res_target(n):
     Note that EU RE directive counts corporate PPA within NECPs.
     """
     # --- Load and prepare RES targets ---
-    df_ember = pd.read_excel(
-        "https://storage.googleapis.com/emb-prod-bkt-publicdata/public-downloads/res_tracker/outputs/targets_download.xlsx",
-        sheet_name="capacity_target_wide",
-    )
+    df_ember = retrieve_ember_data(n.config)
 
     # Convert ISO3 to ISO2, keeping "EU" unchanged
     df_ember["country"] = df_ember["country_code"].apply(
@@ -1556,7 +1615,7 @@ def cfe_constraints(n):
 
     for name in procurement["ci"]:
         location = procurement["ci"][name]["location"]
-        grid_supply_cfe = n.buses_t.cfe_score[location]
+        grid_supply_cfe = n.buses_t.cfe_lvl_score[location]
 
         gen_ci = list(n.generators.query("ci == @name").index) if "ci" in n.generators.columns else []
         links_ci = list(n.links.query("ci == @name").index) if "ci" in n.links.columns else []


### PR DESCRIPTION
Closes #10 

## Changes proposed in this Pull Request

Add key improvements to the preparation of 24/7 CFE runs
- Redistribute CFE share and emissions rates based on power flow
- Ember renewable target are downloaded in the same manner as the CI loads
- Have scenarios to compare the impacts of including and excluding additionality

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
