### PR TITLE
add preexisting capacity of TYNDP without extendability

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -101,6 +101,7 @@ electricity:
 transmission_projects:
   include:
     nep: false
+  new_link_capacity: keep #keep or zero
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:


### PR DESCRIPTION
## Changes proposed in this Pull Request

* The current configuration assumes no expandability of existing transmission lines, reflecting a conservative approach.
* The issue is when it comes to the TYNDP links, they are included in the model but have no assigned capacity.
* A balanced solution, while maintaining conservative assumptions, is to set `new_link_capacity: keep`, aligning with the TYNDP 2030 development plan.


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
