### PR TITLE
Feature/seq run

### DIFF
--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -29,7 +29,7 @@ baseline-1H:
 # ======== Baseline model with volume matching ========
 # =====================================================
 
-vol-match-PL-3H:
+vol-match--3H:
   enable:
     procurement: true
   
@@ -43,68 +43,7 @@ vol-match-PL-3H:
     energy_matching: 100
     participation: 70
 
-    ci:
-      Poland:
-        location: "PL0 0"
-
-vol-match-DE-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Germany:
-        location: "DE0 0"
-
-vol-match-add-DE-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Germany:
-        location: "DE0 0"
-
-vol-match-FR-3H:
-  enable:
-    procurement: true
-  
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      France:
-        location: "FR0 0"
-
-vol-match-add-FR-3H:
+vol-match-add--3H:
   enable:
     procurement: true
   
@@ -121,11 +60,7 @@ vol-match-add-FR-3H:
     energy_matching: 100
     participation: 70
 
-    ci:
-      France:
-        location: "FR0 0"
-
-vol-match-ES-3H:
+vol-match-short--3H:
   enable:
     procurement: true
   
@@ -135,112 +70,12 @@ vol-match-ES-3H:
 
   procurement:
     strategy: vol-match
-    scope: "all"
+    scope: "country"
     energy_matching: 100
     participation: 70
 
-    ci:
-      Spain:
-        location: "ES0 0"
-
-vol-match-add-ES-3H:
-  enable:
-    procurement: true
-  
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Spain:
-        location: "ES0 0"
-
-vol-match-DK-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Denmark:
-        location: "DK0 0"
-
-vol-match-add-DK-3H:
-  enable:
-    procurement: true
-  
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Denmark:
-        location: "DK0 0"
-
-vol-match-IE-3H:
-  enable:
-    procurement: true
-  
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Ireland:
-        location: "IE3 0"
-
-vol-match-add-IE-3H:
-  enable:
-    procurement: true
-  
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: vol-match
-    scope: "all"
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Ireland:
-        location: "IE3 0"
+    strip_snapshots: true
+    strip_network: true
 
 vol-match-PL-DE-FR-ES-DK-IE-3H:
   enable:
@@ -277,7 +112,7 @@ vol-match-PL-DE-FR-ES-DK-IE-3H:
 # ======== Baseline model with 247 CFE matching ========
 # ======================================================
 
-247-cfe-PL-3H:
+247-cfe--3H:
   enable:
     procurement: true
 
@@ -291,50 +126,7 @@ vol-match-PL-DE-FR-ES-DK-IE-3H:
     energy_matching: 100
     participation: 70
 
-    ci:
-      Poland:
-        location: "PL0 0"
-
-247-cfe-add-PL-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Poland:
-        location: "PL0 0"
-
-247-cfe-DE-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Germany:
-        location: "DE0 0"
-
-247-cfe-add-DE-3H:
+247-cfe-add--3H:
   enable:
     procurement: true
 
@@ -351,11 +143,7 @@ vol-match-PL-DE-FR-ES-DK-IE-3H:
     energy_matching: 100
     participation: 70
 
-    ci:
-      Germany:
-        location: "DE0 0"
-
-247-cfe-FR-3H:
+247-cfe-short--3H:
   enable:
     procurement: true
 
@@ -368,146 +156,3 @@ vol-match-PL-DE-FR-ES-DK-IE-3H:
     scope: node
     energy_matching: 100
     participation: 70
-
-    ci:
-      France:
-        location: "FR0 0"
-
-247-cfe-add-FR-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      France:
-        location: "FR0 0"
-
-247-cfe-ES-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Spain:
-        location: "ES0 0"
-
-247-cfe-add-ES-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Spain:
-        location: "ES0 0"
-
-247-cfe-DK-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Denmark:
-        location: "DK0 0"
-
-247-cfe-add-DK-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Denmark:
-        location: "DK0 0"
-
-247-cfe-IE-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Ireland:
-        location: "IE3 0"
-
-247-cfe-add-IE-3H:
-  enable:
-    procurement: true
-
-  electricity:
-   ci_load:
-      profile: "total"
-
-  res_target:
-    res_additionality: true
-
-  procurement:
-    strategy: 247-cfe
-    scope: node
-    energy_matching: 100
-    participation: 70
-
-    ci:
-      Ireland:
-        location: "IE3 0"
-        

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -75,7 +75,7 @@ vol-match-short--3H:
     participation: 70
 
     strip_snapshots: true
-    strip_network: true
+    #strip_network: true
 
 vol-match-PL-DE-FR-ES-DK-IE-3H:
   enable:
@@ -156,3 +156,6 @@ vol-match-PL-DE-FR-ES-DK-IE-3H:
     scope: node
     energy_matching: 100
     participation: 70
+
+    strip_snapshots: true
+    #strip_network: true

--- a/run/name_location_country.csv
+++ b/run/name_location_country.csv
@@ -1,0 +1,35 @@
+name,location,country
+Albania,AL0 0,AL
+Austria,AT0 0,AT
+Bosnia and Herzegovina,BA0 0,BA
+Belgium,BE0 0,BE
+Bulgaria,BG0 0,BG
+Switzerland,CH0 0,CH
+Czech Republic,CZ0 0,CZ
+Germany,DE0 0,DE
+Denmark,DK0 0,DK
+Estonia,EE0 0,EE
+Spain,ES0 0,ES
+Finland,FI1 0,FI
+France,FR0 0,FR
+United Kingdom,GB2 0,GB
+Greece,GR0 0,GR
+Croatia,HR0 0,HR
+Hungary,HU0 0,HU
+Ireland,IE3 0,IE
+Italy,IT0 0,IT
+Latvia,LT0 0,LT
+Luxembourg,LU0 0,LU
+Lithuania,LV0 0,LV
+Montenegro,ME0 0,ME
+North Macedonia,MK0 0,MK
+Netherlands,NL0 0,NL
+Norway,NO1 0,NO
+Poland,PL0 0,PL
+Portugal,PT0 0,PT
+Romania,RO0 0,RO
+Serbia,RS0 0,RS
+Sweden,SE1 0,SE
+Slovenia,SI0 0,SI
+Slovakia,SK0 0,SK
+Kosovo,XK0 0,XK

--- a/run/seq_run.py
+++ b/run/seq_run.py
@@ -1,0 +1,158 @@
+import os
+import shutil
+import yaml
+import pandas as pd
+
+# ---------------------- Utility Functions ----------------------
+
+def deep_update(original, updates):
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(original.get(key), dict):
+            deep_update(original[key], value)
+        else:
+            original[key] = value
+
+def select_scenario(scenarios):
+    print("Available scenarios:")
+    for i, scenario in enumerate(scenarios, 1):
+        print(f"{i}. {scenario}")
+    print("(Scenarios must include '--' in their name)")
+
+    while True:
+        answer = input("Select a scenario as base (or press Enter to cancel): ").strip()
+        if not answer:
+            return None
+        if answer in scenarios:
+            print(f"'{answer}' is selected.")
+            return answer
+        else:
+            print(f"'{answer}' not found in the list. Please try again.")
+
+def select_country(df):
+    print("\nSelect which country or group of countries to execute:")
+    print("  - main: DE, FR, PL, ES, IE, DK")
+    print("  - all: all 34 countries individually")
+
+    while True:
+        answer = input("Select a country or group (or press Enter to cancel): ").strip().lower()
+        if not answer:
+            return None, df
+        elif answer == "all":
+            print("All 34 countries selected.")
+            return "all", df
+        elif answer == "main":
+            countries = ["DE", "FR", "PL", "ES", "IE", "DK"]
+            print(f"Selected main countries: {', '.join(countries)}")
+            return "main", df[df.country.isin(countries)]
+        else:
+            print(f"'{answer}' is not a valid option. Please try again.")
+
+def select_profile():
+    while True:
+        answer = input("Is this in a computer cluster [y/n]?: ").strip().lower()
+        if not answer:
+            return None
+        elif answer in ["y", "yes"]:
+            return "--profile slurm"
+        elif answer in ["n", "no"]:
+            cpu = input("How many CPUs do you want to use (all or a number)? ").strip().lower()
+            if cpu == "all":
+                return "-call"
+            elif cpu.isdigit():
+                return f"-c{cpu}"
+        print(f"'{answer}' is not a valid option. Please try again.")
+
+# ---------------------- Main Script ----------------------
+
+def main():
+    # Load scenario configuration
+    with open('config/scenarios.meta.yaml', 'r') as file:
+        config_s = yaml.safe_load(file)
+
+    df = pd.read_csv("run/name_location_country.csv")
+
+    # Extract scenarios with '--'
+    scenario_list = [key for key in config_s if "--" in key]
+
+    # User input
+    selected_scenario = select_scenario(scenario_list)
+    selected_country, df = select_country(df)
+    selected_profile = select_profile()
+
+    if not selected_scenario or not selected_country or not selected_profile:
+        print("\nOperation cancelled by user.")
+        return
+
+    print("\nFinal selection:")
+    print(f"Scenario: {selected_scenario}")
+    print(f"Country group: {selected_country}")
+    print(f"Profile: {selected_profile}")
+
+    # Iterate runs
+    for i, row in df.iterrows():
+        # Load base config
+        with open('config/config.meta.yaml', 'r') as file:
+            config = yaml.safe_load(file)
+
+        deep_update(config, config_s[selected_scenario])
+
+        # Modify config per country
+        country = row["country"]
+        scenario_name = selected_scenario.replace("--", f"-{country}-")
+
+        config_update = {
+            "run": {
+                "name": scenario_name,
+                "scenarios": {"enable": False}
+            },
+            "procurement": {
+                "ci": {
+                    row["name"]: {"location": row["location"]}
+                }
+            }
+        }
+
+        deep_update(config, config_update)
+
+        # Write temp config
+        with open('run/config.meta_temp.yaml', 'w') as file:
+            yaml.safe_dump(config, file, default_flow_style=False)
+
+        # Prepare resources
+        new_folder = f"resources/{scenario_name}"
+        old_folder = "resources/baseline-3H" if "3H" in scenario_name else "resources/baseline-1H"
+        files_to_copy = ["costs_2030.csv", "networks/base_s_39___2030_brownfield.nc"]
+
+        os.makedirs(os.path.join(new_folder, "networks"), exist_ok=True)
+
+        for f in files_to_copy:
+            old_path = os.path.join(old_folder, f)
+            new_path = os.path.join(new_folder, f)
+            if os.path.isfile(old_path):
+                shutil.copy(old_path, new_path)
+                print(f"Copied {old_path} to {new_path}")
+            else:
+                print(f"WARNING: File not found: {old_path}")
+
+        # Run snakemake
+        run_cmd = f"snakemake {selected_profile} solve_sector_networks --configfile run/config.meta_temp.yaml --rerun-trigger mtime"
+        os.system(run_cmd + " --touch")
+        os.system(run_cmd)
+
+        # Clean up
+        if os.path.exists(new_folder):
+            shutil.rmtree(new_folder)
+            print(f"Deleted folder: {new_folder}")
+        else:
+            print(f"Folder does not exist (already removed?): {new_folder}")
+
+        temp_file = 'run/config.meta_temp.yaml'
+        
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+            print(f"Deleted file: {temp_file}")
+        else:
+            print(f"File does not exist: {temp_file}")
+
+if __name__ == "__main__":
+    main()

--- a/run/seq_run.py
+++ b/run/seq_run.py
@@ -29,23 +29,37 @@ def select_scenario(scenarios):
             print(f"'{answer}' not found in the list. Please try again.")
 
 def select_country(df):
+    available_countries = set(df["country"].unique())
+    main_countries = {"DE", "FR", "PL", "ES", "IE", "DK"}
+
     print("\nSelect which country or group of countries to execute:")
     print("  - main: DE, FR, PL, ES, IE, DK")
     print("  - all: all 34 countries individually")
+    print("  - or enter country codes separated by commas (e.g., DE,FR,PL)")
 
     while True:
         answer = input("Select a country or group (or press Enter to cancel): ").strip().lower()
         if not answer:
             return None, df
-        elif answer == "all":
+
+        if answer == "all":
             print("All 34 countries selected.")
             return "all", df
+
         elif answer == "main":
-            countries = ["DE", "FR", "PL", "ES", "IE", "DK"]
-            print(f"Selected main countries: {', '.join(countries)}")
-            return "main", df[df.country.isin(countries)]
+            print(f"Selected main countries: {', '.join(sorted(main_countries))}")
+            return "main", df[df["country"].isin(main_countries)]
+
         else:
-            print(f"'{answer}' is not a valid option. Please try again.")
+            # Split and normalize input
+            selected = {code.strip().upper() for code in answer.split(",")}
+            invalid = selected - available_countries
+
+            if invalid:
+                print(f"Invalid country code(s): {', '.join(sorted(invalid))}. Please try again.")
+            else:
+                print(f"Selected countries: {', '.join(sorted(selected))}")
+                return ",".join(sorted(selected)), df[df["country"].isin(selected)]
 
 def select_profile():
     while True:
@@ -76,10 +90,17 @@ def main():
 
     # User input
     selected_scenario = select_scenario(scenario_list)
-    selected_country, df = select_country(df)
-    selected_profile = select_profile()
+    if not selected_scenario:
+        print("\nOperation cancelled by user.")
+        return
 
-    if not selected_scenario or not selected_country or not selected_profile:
+    selected_country, df = select_country(df)
+    if not selected_country:
+        print("\nOperation cancelled by user.")
+        return
+
+    selected_profile = select_profile()
+    if not selected_profile:
         print("\nOperation cancelled by user.")
         return
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -2676,6 +2676,12 @@ if __name__ == "__main__":
                 print("stript_network is activated")
                 strip_network(n, procurement)
 
+            if procurement["strip_snapshots"]:
+                print("stript_snapshots is activated")
+                m = n.copy()
+                m.set_snapshots(n.snapshots[:168])
+                n = m.copy()
+
             Nyears = n.snapshot_weightings.objective.sum() / 8760.0
             costs = load_costs(
                 snakemake.input.costs,

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -2672,11 +2672,11 @@ if __name__ == "__main__":
         ):
             procurement = snakemake.params.procurement
 
-            if procurement["strip_network"]:
+            if procurement.get("strip_network", False):
                 print("stript_network is activated")
                 strip_network(n, procurement)
 
-            if procurement["strip_snapshots"]:
+            if procurement.get("strip_snapshots", False):
                 print("stript_snapshots is activated")
                 m = n.copy()
                 m.set_snapshots(n.snapshots[:168])


### PR DESCRIPTION
Closes #19 .

## Changes proposed in this Pull Request

This script in run enables computer cluster and personal computer to run the script sequentially:
```
python run/seq_run.py
```
There is a simple command line interface asking:
- scenarios selected (must contain --)
- countries selected
- profile selected. If not in computer cluster, select the number of CPU used.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
