### PR TITLE
bugfix: use config instead of params to enable procurement

### DIFF
--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1974,7 +1974,7 @@ def extra_functionality(
     if config.get("res_target", False) and planning_horizons == "2030":
         ember_res_target(n)
 
-    if n.params.get("procurement_enable", False):
+    if config["enable"].get("procurement", False):
         procurement = config["procurement"]
         strategy = procurement["strategy"]
         energy_matching = procurement["energy_matching"]
@@ -2146,8 +2146,8 @@ def solve_network(
         n.optimize.optimize_with_rolling_horizon(**kwargs)
         status, condition = "", ""
     elif (
-        n.params.get("procurement_enable", False)
-        and n.params.procurement.get("strategy", False) == "247-cfe"
+        config["enable"].get("procurement", False)
+        and config["procurement"].get("strategy", False) == "247-cfe"
     ):
         status, condition = optimize_model_iteratively(n, config, **kwargs)
     elif skip_iterations:


### PR DESCRIPTION
## Changes proposed in this Pull Request

Set the procurement selection as configs instead of params

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
