### PR TITLE
feat: aggregate CI generators in annual volume matching (draft

### DIFF
--- a/config/config.meta.yaml
+++ b/config/config.meta.yaml
@@ -22,7 +22,7 @@ remote:
 run:
   prefix: ""
   name:
-  - baseline-2030-1H
+  - vol-match-2030-ci25-continent-6-3H
   scenarios:
     enable: true
     file: config/scenarios.meta.yaml
@@ -199,7 +199,7 @@ grid_policy:
 
 procurement:
   strategy: emi-match # name of procurement strategy: vol-match, emi-match, 247-cfe
-  scope: "all" # "node", "country", "all"
+  scope: "all" # "node", "country", "all", "continent"
   energy_matching: 100 # share of CI energy demand to be procured
   emissionality:
     emission_matching: 100 # share of CI emissions to be compensated

--- a/config/scenarios.meta.yaml
+++ b/config/scenarios.meta.yaml
@@ -207,7 +207,42 @@ vol-match-2030-NoResTargets-ci25-3H: #4
       United Kingdom:
         location: "GB2 0"
 
-vol-match-2030-ci25-continent-3H: #bonus
+vol-match-2030-ci25-continent-6-3H: #bonus
+  enable:
+    procurement: true
+
+  clustering:
+    temporal:
+      resolution_sector: 3H
+  
+  solving:
+    mem_mb: 150000
+    runtime: 24h
+
+  res_target:
+    res_additionality: false
+
+  procurement:
+    strategy: vol-match
+    scope: "continent"
+    energy_matching: 100
+    participation: 50
+
+    ci:
+      Poland:
+        location: "PL0 0"
+      Germany:
+        location: "DE0 0"
+      France:
+        location: "FR0 0"
+      Spain:
+        location: "ES0 0"
+      Italy:
+        location: "IT0 0"
+      United Kingdom:
+        location: "GB2 0"
+
+vol-match-2030-ci25-continent-34-3H: #bonus
   enable:
     procurement: true
 
@@ -216,15 +251,15 @@ vol-match-2030-ci25-continent-3H: #bonus
       resolution_sector: 3H
 
   solving:
-    mem_mb: 600000
-    runtime: 48h
+    mem_mb: 150000
+    runtime: 24h
 
   res_target:
     res_additionality: false
 
   procurement:
     strategy: vol-match
-    scope: "all"
+    scope: "continent"
     energy_matching: 100
     participation: 50
 

--- a/scripts/add_procurement.py
+++ b/scripts/add_procurement.py
@@ -564,7 +564,7 @@ def add_ci_procurement(n: pypsa.Network, year: str, config: dict, costs: pd.Data
 
             res_df = n.generators.loc[mask].copy()
 
-            res_df["gen_name"] = name + " " + res_df.index
+            res_df["gen_name"] = "CI" + " " + res_df.index if scope == "continent" else name + " " + res_df.index
             res_df["bus_name"] = name if scope == "node" else res_df["bus"]
             res_df["capital_cost"] = n.generators.loc[res_df.index,"capital_cost"]
             res_df["marginal_cost"] = n.generators.loc[res_df.index,"marginal_cost"]
@@ -583,7 +583,7 @@ def add_ci_procurement(n: pypsa.Network, year: str, config: dict, costs: pd.Data
                 p_max_pu=p_max_pu_df,
                 capital_cost=res_df["capital_cost"],
                 marginal_cost=res_df["marginal_cost"],
-                ci=name,  # C&I markers used in constraints
+                ci="continent" if scope == "continent" else name,  # C&I markers used in constraints
             )
 
         logger.info(
@@ -763,7 +763,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "add_procurement",
-            run= "emi-match-DK-3H",
+            run= "vol-match-2030-ci25-continent-6-3H",
             opts="",
             clusters="39",
             configfiles="config/config.meta.yaml",

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1611,11 +1611,14 @@ def res_annual_matching_constraints(n):
     """
     weights = n.snapshot_weightings["generators"]
     energy_matching = n.config["procurement"]["energy_matching"] / 100
-    strategy = n.config["procurement"]["strategy"]
 
-    for name in n.config["procurement"]["ci"]:
-        gen_ci = list(n.generators.query("ci == @name").index) if "ci" in n.generators.columns else []
-        links_ci = list(n.links.query("ci == @name").index) if "ci" in n.links.columns else []
+    if n.config["procurement"]["scope"] == "continent":
+        total_load = 0
+        for name in n.config["procurement"]["ci"]:
+            total_load += (n.loads_t.p_set[name + " load"] * weights).sum()
+
+        gen_ci = list(n.generators[n.generators.ci == "continent"].index) if "ci" in n.generators.columns else []
+        links_ci = list(n.links[n.links.ci == "continent"].index) if "ci" in n.links.columns else []
 
         gen_sum = (n.model["Generator-p"].loc[:, gen_ci] * weights).sum()
         link_sum = (
@@ -1625,11 +1628,27 @@ def res_annual_matching_constraints(n):
         ).sum()
         lhs = gen_sum + link_sum
 
-        total_load = (n.loads_t.p_set[name + " load"] * weights).sum()
-
         n.model.add_constraints(
-                lhs == energy_matching * total_load, name=f"RES_annual_matching_{name}"
+                lhs == energy_matching * total_load, name=f"RES_annual_matching_continent"
             )
+    else:
+        for name in n.config["procurement"]["ci"]:
+            gen_ci = list(n.generators.query("ci == @name").index) if "ci" in n.generators.columns else []
+            links_ci = list(n.links.query("ci == @name").index) if "ci" in n.links.columns else []
+
+            gen_sum = (n.model["Generator-p"].loc[:, gen_ci] * weights).sum()
+            link_sum = (
+                n.model["Link-p"].loc[:, links_ci]
+                * n.links.loc[links_ci].efficiency
+                * weights
+            ).sum()
+            lhs = gen_sum + link_sum
+
+            total_load = (n.loads_t.p_set[name + " load"] * weights).sum()
+
+            n.model.add_constraints(
+                    lhs == energy_matching * total_load, name=f"RES_annual_matching_{name}"
+                )
 
 
 def cfe_constraints(n):
@@ -2178,7 +2197,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "solve_sector_network_myopic",
-            run= "emi-match-DK-3H",
+            run= "vol-match-2030-ci25-continent-6-3H",
             opts="",
             clusters="39",
             configfiles="config/config.meta.yaml",


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR add a new procurement scope named `continent`:
- The scope provides for the aggregation of CI generators
- The scope can only be applied to annual volume matching and emission matching procurement strategies

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
